### PR TITLE
Add accumulator service

### DIFF
--- a/cmd/accumulator/main.go
+++ b/cmd/accumulator/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"github.com/thingspect/atlas/internal/accumulator/accumulator"
+	"github.com/thingspect/atlas/internal/accumulator/config"
+	"github.com/thingspect/atlas/pkg/alog"
+)
+
+func main() {
+	cfg := config.New()
+
+	alog.SetGlobal(alog.NewJSON().WithLevel(cfg.LogLevel).WithStr("service",
+		accumulator.ServiceName))
+
+	// Build Accumulator.
+	acc, err := accumulator.New(cfg)
+	if err != nil {
+		alog.Fatalf("main accumulator.New: %v", err)
+	}
+
+	// Serve connections.
+	acc.Serve(cfg.Concurrency)
+}

--- a/config/db/atlas/000030_add_data_points.down.sql
+++ b/config/db/atlas/000030_add_data_points.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS data_points;

--- a/config/db/atlas/000030_add_data_points.up.sql
+++ b/config/db/atlas/000030_add_data_points.up.sql
@@ -1,0 +1,14 @@
+CREATE TABLE data_points (
+  org_id uuid NOT NULL,
+  uniq_id varchar(40) NOT NULL CHECK (uniq_id = lower(uniq_id)),
+  attr varchar(40) NOT NULL,
+  int_val bigint,
+  fl64_val double precision,
+  str_val varchar(255),
+  bool_val boolean,
+  bytes_val bytea CHECK (octet_length(bytes_val) <= 255),
+  created_at timestamptz NOT NULL,
+  trace_id uuid NOT NULL,
+  PRIMARY KEY (org_id, uniq_id, attr, created_at),
+  CHECK (num_nonnulls(int_val, fl64_val, str_val, bool_val, bytes_val) = 1)
+);

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/golang/protobuf v1.4.3
 	github.com/golang/snappy v0.0.2 // indirect
 	github.com/google/uuid v1.1.2
+	github.com/jackc/pgconn v1.8.0
 	github.com/jackc/pgx/v4 v4.10.0
 	github.com/lib/pq v1.8.0 // indirect
 	github.com/nsqio/go-nsq v1.0.8
@@ -16,9 +17,10 @@ require (
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/stretchr/testify v1.6.1
 	github.com/thingspect/api/go v0.0.0-20201208033745-19824523b926
-	golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c // indirect
-	golang.org/x/net v0.0.0-20201207224615-747e23833adb // indirect
+	golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9 // indirect
+	golang.org/x/net v0.0.0-20201209123823-ac852fbbde11 // indirect
 	golang.org/x/text v0.3.4 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/protobuf v1.25.0
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c h1:9HhBz5L/UjnK9XLtiZhYAdue5BVKep3PMmS2LuPDt8k=
-golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
+golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9 h1:sYNJzB4J8toYPQTM6pAkcmBRgw9SnQKP9oXCHfgy604=
+golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
@@ -188,8 +188,8 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwL
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200425230154-ff2c4b7c35a0/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
-golang.org/x/net v0.0.0-20201207224615-747e23833adb h1:xj2oMIbduz83x7tzglytWT7spn6rP+9hvKjTpro6/pM=
-golang.org/x/net v0.0.0-20201207224615-747e23833adb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201209123823-ac852fbbde11 h1:lwlPPsmjDKK0J6eG6xDWd5XPehI0R024zxjDnw3esPA=
+golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -207,8 +207,9 @@ golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
@@ -260,6 +261,8 @@ gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec/go.mod h1:a
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
+gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=

--- a/internal/accumulator/accumulator/accumulate.go
+++ b/internal/accumulator/accumulator/accumulate.go
@@ -1,0 +1,65 @@
+package accumulator
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/thingspect/atlas/api/go/message"
+	"github.com/thingspect/atlas/pkg/alog"
+	"github.com/thingspect/atlas/pkg/dao/datapoint"
+	"google.golang.org/protobuf/proto"
+)
+
+// accumulateMessages accumulates data point messages and stores them.
+func (acc *Accumulator) accumulateMessages() {
+	alog.Info("accumulateMessages starting processor")
+
+	var processCount int
+	for msg := range acc.vOutSub.C() {
+		// Retrieve published message.
+		vOut := &message.ValidatorOut{}
+		err := proto.Unmarshal(msg.Payload(), vOut)
+		if err != nil || vOut.Point == nil {
+			msg.Ack()
+			alog.Errorf("validateMessages proto.Unmarshal vOut, err: %+v, %v",
+				vOut, err)
+			continue
+		}
+
+		// Set up logging fields.
+		logFields := map[string]interface{}{
+			"traceID": vOut.Point.TraceId,
+			"orgID":   vOut.OrgId,
+			"uniqID":  vOut.Point.UniqId,
+			"devID":   vOut.DevId,
+		}
+		logEntry := alog.WithFields(logFields)
+
+		// Create data point.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		err = acc.dpDAO.Create(ctx, vOut.Point, vOut.OrgId)
+		cancel()
+		if errors.Is(err, datapoint.ErrDuplicate) ||
+			errors.Is(err, datapoint.ErrBadFormat) {
+			logEntry.Errorf("accumulateMessages discard acc.dpDAO.Create: %v",
+				err)
+			msg.Ack()
+			continue
+		}
+		if err != nil {
+			logEntry.Errorf("accumulateMessages requeue acc.dpDAO.Create: %v",
+				err)
+			msg.Requeue()
+			continue
+		}
+
+		msg.Ack()
+		logEntry.Debugf("accumulateMessages created: %+v", vOut)
+
+		processCount++
+		if processCount%100 == 0 {
+			alog.Infof("accumulateMessages processed %v messages", processCount)
+		}
+	}
+}

--- a/internal/accumulator/accumulator/accumulate_test.go
+++ b/internal/accumulator/accumulator/accumulate_test.go
@@ -1,0 +1,150 @@
+// +build !integration
+
+package accumulator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/thingspect/api/go/common"
+	"github.com/thingspect/atlas/api/go/message"
+	"github.com/thingspect/atlas/pkg/dao/datapoint"
+	"github.com/thingspect/atlas/pkg/queue"
+	"github.com/thingspect/atlas/pkg/test/random"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+var errTestProc = errors.New("accumulator: test processor error")
+
+type fakeDataPointer struct {
+	fCreate func() error
+}
+
+func newFakeDataPointer() *fakeDataPointer {
+	return &fakeDataPointer{
+		fCreate: func() error { return nil },
+	}
+}
+
+func (fp *fakeDataPointer) Create(ctx context.Context, dp *common.DataPoint,
+	orgID string) error {
+	return fp.fCreate()
+}
+
+func TestAccumulateMessages(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		inp *message.ValidatorOut
+	}{
+		{&message.ValidatorOut{Point: &common.DataPoint{
+			UniqId: random.String(16), Attr: "motion",
+			ValOneof: &common.DataPoint_IntVal{IntVal: 123},
+			Ts:       timestamppb.New(time.Now().Add(-15 * time.Minute)),
+			Token:    uuid.New().String(), TraceId: uuid.New().String()},
+			OrgId: uuid.New().String()}},
+		{&message.ValidatorOut{Point: &common.DataPoint{
+			UniqId: random.String(16), Attr: "temp",
+			ValOneof: &common.DataPoint_Fl64Val{Fl64Val: 9.3},
+			Ts:       timestamppb.New(time.Now().Add(-15 * time.Minute)),
+			Token:    uuid.New().String(), TraceId: uuid.New().String()},
+			OrgId: uuid.New().String()}},
+		{&message.ValidatorOut{Point: &common.DataPoint{
+			UniqId: random.String(16), Attr: "power",
+			ValOneof: &common.DataPoint_StrVal{StrVal: "batt"},
+			Ts:       timestamppb.New(time.Now().Add(-15 * time.Minute)),
+			Token:    uuid.New().String(), TraceId: uuid.New().String()},
+			OrgId: uuid.New().String()}},
+	}
+
+	for _, test := range tests {
+		lTest := test
+
+		t.Run(fmt.Sprintf("Can accumulate %+v", lTest), func(t *testing.T) {
+			t.Parallel()
+
+			vOutQueue := queue.NewFake()
+			vOutSub, err := vOutQueue.Subscribe("")
+			require.NoError(t, err)
+
+			acc := Accumulator{
+				dpDAO:     newFakeDataPointer(),
+				vOutQueue: vOutQueue,
+				vOutSub:   vOutSub,
+			}
+			go func() {
+				acc.accumulateMessages()
+			}()
+
+			bVOut, err := proto.Marshal(lTest.inp)
+			require.NoError(t, err)
+			t.Logf("bVOut: %s", bVOut)
+
+			require.NoError(t, vOutQueue.Publish("", bVOut))
+		})
+	}
+}
+
+func TestAccumulateMessagesError(t *testing.T) {
+	t.Parallel()
+
+	duplicateDataPointer := newFakeDataPointer()
+	duplicateDataPointer.fCreate = func() error {
+		return datapoint.ErrDuplicate
+	}
+
+	errDataPointer := newFakeDataPointer()
+	errDataPointer.fCreate = func() error {
+		return errTestProc
+	}
+
+	tests := []struct {
+		inpDataPointer *fakeDataPointer
+		inpVOut        *message.ValidatorOut
+	}{
+		// Bad payload.
+		{newFakeDataPointer(), nil},
+		// Duplicate data point.
+		{duplicateDataPointer,
+			&message.ValidatorOut{Point: &common.DataPoint{}}},
+		// DataPointer error.
+		{errDataPointer, &message.ValidatorOut{Point: &common.DataPoint{}}},
+	}
+
+	for _, test := range tests {
+		lTest := test
+
+		t.Run(fmt.Sprintf("Cannot accumulate %+v", lTest), func(t *testing.T) {
+			t.Parallel()
+
+			vOutQueue := queue.NewFake()
+			vOutSub, err := vOutQueue.Subscribe("")
+			require.NoError(t, err)
+
+			acc := Accumulator{
+				dpDAO:     lTest.inpDataPointer,
+				vOutQueue: vOutQueue,
+				vOutSub:   vOutSub,
+			}
+			go func() {
+				acc.accumulateMessages()
+			}()
+
+			bVOut := []byte("val-aaa")
+			if lTest.inpVOut != nil {
+				var err error
+				bVOut, err = proto.Marshal(lTest.inpVOut)
+				require.NoError(t, err)
+				t.Logf("bVOut: %s", bVOut)
+			}
+
+			require.NoError(t, vOutQueue.Publish("", bVOut))
+		})
+	}
+}

--- a/internal/accumulator/accumulator/accumulator.go
+++ b/internal/accumulator/accumulator/accumulator.go
@@ -1,0 +1,79 @@
+// Package accumulator provides functions used to run the Accumulator service.
+package accumulator
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/thingspect/api/go/common"
+	"github.com/thingspect/atlas/internal/accumulator/config"
+	"github.com/thingspect/atlas/pkg/alog"
+	"github.com/thingspect/atlas/pkg/dao/datapoint"
+	"github.com/thingspect/atlas/pkg/postgres"
+	"github.com/thingspect/atlas/pkg/queue"
+)
+
+const (
+	ServiceName = "accumulator"
+)
+
+// datapointer defines the methods provided by a datapoint.DAO.
+type datapointer interface {
+	Create(ctx context.Context, dp *common.DataPoint, orgID string) error
+}
+
+// Accumulator holds references to the database and message broker connections.
+type Accumulator struct {
+	dpDAO     datapointer
+	vOutQueue queue.Queuer
+	vOutSub   queue.Subber
+}
+
+// New builds a new Accumulator and returns a reference to it and an error
+// value.
+func New(cfg *config.Config) (*Accumulator, error) {
+	// Set up database connection.
+	pg, err := postgres.New(cfg.PgURI)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build the NSQ connection for consuming.
+	nsq, err := queue.NewNSQ(cfg.NSQPubAddr, cfg.NSQLookupAddrs,
+		cfg.NSQSubChannel, queue.DefaultNSQRequeueDelay)
+	if err != nil {
+		return nil, err
+	}
+
+	// Subscribe to the topic.
+	vOutSub, err := nsq.Subscribe(cfg.NSQSubTopic)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Accumulator{
+		dpDAO:     datapoint.NewDAO(pg),
+		vOutQueue: nsq,
+		vOutSub:   vOutSub,
+	}, nil
+}
+
+// Serve starts the message parsers.
+func (acc *Accumulator) Serve(concurrency int) {
+	for i := 0; i < concurrency; i++ {
+		go acc.accumulateMessages()
+	}
+
+	// Handle graceful shutdown.
+	exitChan := make(chan os.Signal, 1)
+	signal.Notify(exitChan, syscall.SIGINT, syscall.SIGTERM)
+	<-exitChan
+
+	alog.Info("Serve received signal, exiting")
+	if err := acc.vOutSub.Unsubscribe(); err != nil {
+		alog.Errorf("Serve acc.subber.Unsubscribe: %v", err)
+	}
+	acc.vOutQueue.Disconnect()
+}

--- a/internal/accumulator/config/config.go
+++ b/internal/accumulator/config/config.go
@@ -1,0 +1,39 @@
+// Package config provides configuration values and defaults for the Accumulator
+// service.
+package config
+
+import "github.com/thingspect/atlas/pkg/config"
+
+const pref = "ACCUMULATOR_"
+
+// Config holds settings used by the Accumulator service.
+type Config struct {
+	LogLevel string
+
+	PgURI string
+
+	NSQLookupAddrs []string
+	NSQSubTopic    string
+	NSQSubChannel  string
+
+	NSQPubAddr  string
+	Concurrency int
+}
+
+// New instantiates a service Config, parses the environment, and returns it.
+func New() *Config {
+	return &Config{
+		LogLevel: config.String(pref+"LOG_LEVEL", "DEBUG"),
+
+		PgURI: config.String(pref+"PG_URI",
+			"postgres://postgres:postgres@127.0.0.1/atlas"),
+
+		NSQLookupAddrs: config.StringSlice(pref+"NSQ_LOOKUP_ADDRS",
+			[]string{"127.0.0.1:4161"}),
+		NSQSubTopic:   config.String(pref+"NSQ_SUB_TOPIC", "ValidatorOut"),
+		NSQSubChannel: config.String(pref+"NSQ_SUB_CHANNEL", "accumulator"),
+
+		NSQPubAddr:  config.String(pref+"NSQ_PUB_ADDR", "127.0.0.1:4150"),
+		Concurrency: config.Int(pref+"CONCURRENCY", 5),
+	}
+}

--- a/internal/accumulator/test/accumulator_test.go
+++ b/internal/accumulator/test/accumulator_test.go
@@ -1,0 +1,131 @@
+// +build !unit
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/thingspect/api/go/common"
+	"github.com/thingspect/atlas/api/go/message"
+	"github.com/thingspect/atlas/pkg/test/random"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestAccumulateMessages(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		inp *message.ValidatorOut
+	}{
+		{&message.ValidatorOut{Point: &common.DataPoint{
+			UniqId: random.String(16), Attr: "motion",
+			ValOneof: &common.DataPoint_IntVal{IntVal: 123},
+			Ts:       timestamppb.New(time.Now().Add(-15 * time.Minute)),
+			Token:    uuid.New().String(), TraceId: uuid.New().String()},
+			OrgId: uuid.New().String()}},
+		{&message.ValidatorOut{Point: &common.DataPoint{
+			UniqId: random.String(16), Attr: "temp",
+			ValOneof: &common.DataPoint_Fl64Val{Fl64Val: 9.3},
+			Ts:       timestamppb.New(time.Now().Add(-15 * time.Minute)),
+			Token:    uuid.New().String(), TraceId: uuid.New().String()},
+			OrgId: uuid.New().String()}},
+		{&message.ValidatorOut{Point: &common.DataPoint{
+			UniqId: random.String(16), Attr: "power",
+			ValOneof: &common.DataPoint_StrVal{StrVal: "batt"},
+			Ts:       timestamppb.New(time.Now().Add(-15 * time.Minute)),
+			Token:    uuid.New().String(), TraceId: uuid.New().String()},
+			OrgId: uuid.New().String()}},
+	}
+
+	for _, test := range tests {
+		lTest := test
+
+		t.Run(fmt.Sprintf("Can accumulate %+v", lTest), func(t *testing.T) {
+			t.Parallel()
+
+			bVOut, err := proto.Marshal(lTest.inp)
+			require.NoError(t, err)
+			t.Logf("bVOut: %s", bVOut)
+
+			require.NoError(t, globalVOutQueue.Publish(globalVOutSubTopic,
+				bVOut))
+			time.Sleep(time.Second)
+
+			ctx, cancel := context.WithTimeout(context.Background(),
+				2*time.Second)
+			defer cancel()
+
+			listPoints, err := globalDPDAO.List(ctx, lTest.inp.OrgId,
+				lTest.inp.Point.UniqId, lTest.inp.Point.Ts.AsTime(),
+				lTest.inp.Point.Ts.AsTime())
+			t.Logf("listPoints, err: %+v, %v", listPoints, err)
+			require.NoError(t, err)
+			require.Len(t, listPoints, 1)
+
+			// Normalize token.
+			listPoints[0].Token = lTest.inp.Point.Token
+			// Normalize timestamp.
+			lTest.inp.Point.Ts = timestamppb.New(
+				lTest.inp.Point.Ts.AsTime().Truncate(time.Millisecond))
+
+			// Testify does not currently support protobuf equality:
+			// https://github.com/stretchr/testify/issues/758
+			if !proto.Equal(lTest.inp.Point, listPoints[0]) {
+				t.Fatalf("\nExpect: %+v\nActual: %+v", lTest.inp.Point,
+					listPoints[0])
+			}
+		})
+	}
+}
+
+func TestAccumulateMessagesDuplicate(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	duplicateVOut := &message.ValidatorOut{Point: &common.DataPoint{
+		UniqId: random.String(16), Attr: "motion",
+		ValOneof: &common.DataPoint_IntVal{IntVal: 123},
+		Ts:       timestamppb.New(time.Now().Add(-15 * time.Minute)),
+		Token:    uuid.New().String(), TraceId: uuid.New().String()},
+		OrgId: uuid.New().String()}
+	require.NoError(t, globalDPDAO.Create(ctx, duplicateVOut.Point,
+		duplicateVOut.OrgId))
+
+	bVOut, err := proto.Marshal(duplicateVOut)
+	require.NoError(t, err)
+	t.Logf("bVOut: %s", bVOut)
+
+	require.NoError(t, globalVOutQueue.Publish(globalVOutSubTopic, bVOut))
+	time.Sleep(time.Second)
+
+	ctx, cancel = context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	listPoints, err := globalDPDAO.List(ctx, duplicateVOut.OrgId,
+		duplicateVOut.Point.UniqId, duplicateVOut.Point.Ts.AsTime(),
+		duplicateVOut.Point.Ts.AsTime())
+	t.Logf("listPoints, err: %+v, %v", listPoints, err)
+	require.NoError(t, err)
+	require.Len(t, listPoints, 1)
+
+	// Normalize token.
+	listPoints[0].Token = duplicateVOut.Point.Token
+	// Normalize timestamp.
+	duplicateVOut.Point.Ts = timestamppb.New(
+		duplicateVOut.Point.Ts.AsTime().Truncate(time.Millisecond))
+
+	// Testify does not currently support protobuf equality:
+	// https://github.com/stretchr/testify/issues/758
+	if !proto.Equal(duplicateVOut.Point, listPoints[0]) {
+		t.Fatalf("\nExpect: %+v\nActual: %+v", duplicateVOut.Point,
+			listPoints[0])
+	}
+}

--- a/internal/accumulator/test/main_test.go
+++ b/internal/accumulator/test/main_test.go
@@ -1,0 +1,75 @@
+// +build !unit
+
+package test
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	"github.com/thingspect/atlas/internal/accumulator/accumulator"
+	"github.com/thingspect/atlas/internal/accumulator/config"
+	"github.com/thingspect/atlas/pkg/dao/datapoint"
+	"github.com/thingspect/atlas/pkg/postgres"
+	"github.com/thingspect/atlas/pkg/queue"
+	testconfig "github.com/thingspect/atlas/pkg/test/config"
+	"github.com/thingspect/atlas/pkg/test/random"
+)
+
+var (
+	globalVOutSubTopic string
+	globalVOutQueue    queue.Queuer
+
+	globalDPDAO *datapoint.DAO
+)
+
+func TestMain(m *testing.M) {
+	// Set up Config.
+	testConfig := testconfig.New()
+	cfg := config.New()
+	cfg.PgURI = testConfig.PgURI
+
+	cfg.NSQLookupAddrs = testConfig.NSQLookupAddrs
+	cfg.NSQSubTopic += "-test-" + random.String(10)
+	globalVOutSubTopic = cfg.NSQSubTopic
+	log.Printf("TestMain cfg.NSQSubTopic: %v", cfg.NSQSubTopic)
+	// Use a unique channel for each test run. This prevents failed tests from
+	// interfering with the next run, but does require eventual cleaning.
+	cfg.NSQSubChannel = "accumulator-test-" + random.String(10)
+	cfg.NSQPubAddr = testConfig.NSQPubAddr
+
+	// Set up NSQ queue to publish test payloads.
+	var err error
+	globalVOutQueue, err = queue.NewNSQ(cfg.NSQPubAddr, nil, "",
+		queue.DefaultNSQRequeueDelay)
+	if err != nil {
+		log.Fatalf("TestMain globalVOutQueue queue.NewNSQ: %v", err)
+	}
+
+	// Publish a throwaway message before subscribe to allow for discovery by
+	// nsqlookupd.
+	if err = globalVOutQueue.Publish(cfg.NSQSubTopic,
+		[]byte("acc-aaa")); err != nil {
+		log.Fatalf("TestMain globalVOutQueue.Publish: %v", err)
+	}
+
+	// Set up Accumulator.
+	acc, err := accumulator.New(cfg)
+	if err != nil {
+		log.Fatalf("TestMain accumulator.New: %v", err)
+	}
+
+	// Serve connections.
+	go func() {
+		acc.Serve(cfg.Concurrency)
+	}()
+
+	// Set up database connection.
+	pg, err := postgres.New(cfg.PgURI)
+	if err != nil {
+		log.Fatalf("TestMain postgres.New: %v", err)
+	}
+	globalDPDAO = datapoint.NewDAO(pg)
+
+	os.Exit(m.Run())
+}

--- a/internal/mqtt-ingestor/ingestor/parse.go
+++ b/internal/mqtt-ingestor/ingestor/parse.go
@@ -50,7 +50,7 @@ func (ing *Ingestor) parseMessages() {
 			logEntry.Errorf("parseMessages proto.Unmarshal: %v", err)
 			continue
 		}
-		logEntry.Debugf("parseMessages payl: %#v", payl)
+		logEntry.Debugf("parseMessages payl: %+v", payl)
 
 		// Build and publish ValidatorIn messages.
 		var successCount int
@@ -68,7 +68,9 @@ func (ing *Ingestor) parseMessages() {
 				logEntry.Errorf("parseMessages ing.parserPub.Publish: %v", err)
 				continue
 			}
+
 			successCount++
+			logEntry.Debugf("parseMessages published: %+v", vIn)
 		}
 
 		// Do not ack on errors, as publish may retry successfully.

--- a/internal/mqtt-ingestor/ingestor/parse_test.go
+++ b/internal/mqtt-ingestor/ingestor/parse_test.go
@@ -24,11 +24,11 @@ func TestParseMessages(t *testing.T) {
 	t.Parallel()
 
 	orgID := uuid.New().String()
-	paylToken := uuid.New().String()
-	pointToken := uuid.New().String()
-	uniqIDTopic := random.String(16)
 	uniqIDPoint := random.String(16)
 	now := timestamppb.New(time.Now().Add(-15 * time.Minute))
+	pointToken := uuid.New().String()
+	uniqIDTopic := random.String(16)
+	paylToken := uuid.New().String()
 
 	tests := []struct {
 		inpTopicParts []string
@@ -120,10 +120,10 @@ func TestParseMessages(t *testing.T) {
 				// Testify does not currently support protobuf equality:
 				// https://github.com/stretchr/testify/issues/758
 				if !proto.Equal(lTest.res, vIn) {
-					t.Fatalf("Expected, actual: %+v, %+v", lTest.res, vIn)
+					t.Fatalf("\nExpect: %+v\nActual: %+v", lTest.res, vIn)
 				}
 			case <-time.After(2 * time.Second):
-				t.Error("Message timed out")
+				t.Fatal("Message timed out")
 			}
 		})
 	}
@@ -176,7 +176,7 @@ func TestParseMessagesError(t *testing.T) {
 
 			select {
 			case msg := <-parserSub.C():
-				t.Errorf("Received unexpected msg.Topic, msg.Payload: %v, %s",
+				t.Fatalf("Received unexpected msg.Topic, msg.Payload: %v, %s",
 					msg.Topic(), msg.Payload())
 			case <-time.After(100 * time.Millisecond):
 				// Successful timeout without publish (normally 0.02s).
@@ -189,12 +189,12 @@ func TestDataPointToVIn(t *testing.T) {
 	t.Parallel()
 
 	orgID := uuid.New().String()
-	traceID := uuid.New().String()
-	paylToken := uuid.New().String()
-	pointToken := uuid.New().String()
-	uniqIDTopic := random.String(16)
 	uniqIDPoint := random.String(16)
 	now := timestamppb.New(time.Now().Add(-15 * time.Minute))
+	pointToken := uuid.New().String()
+	traceID := uuid.New().String()
+	uniqIDTopic := random.String(16)
+	paylToken := uuid.New().String()
 
 	tests := []struct {
 		inpTopicParts []string
@@ -246,7 +246,7 @@ func TestDataPointToVIn(t *testing.T) {
 			// Testify does not currently support protobuf equality:
 			// https://github.com/stretchr/testify/issues/758
 			if !proto.Equal(lTest.res, res) {
-				t.Fatalf("Expected, actual: %+v, %+v", lTest.res, res)
+				t.Fatalf("\nExpect: %+v\nActual: %+v", lTest.res, res)
 			}
 		})
 	}

--- a/internal/mqtt-ingestor/test/ingestor_test.go
+++ b/internal/mqtt-ingestor/test/ingestor_test.go
@@ -21,11 +21,11 @@ import (
 
 func TestParseMessages(t *testing.T) {
 	orgID := uuid.New().String()
-	paylToken := uuid.New().String()
-	pointToken := uuid.New().String()
-	uniqIDTopic := random.String(16)
 	uniqIDPoint := random.String(16)
 	now := timestamppb.New(time.Now().Add(-15 * time.Minute))
+	pointToken := uuid.New().String()
+	uniqIDTopic := random.String(16)
+	paylToken := uuid.New().String()
 
 	tests := []struct {
 		inpTopicParts []string
@@ -86,7 +86,7 @@ func TestParseMessages(t *testing.T) {
 
 				vIn := &message.ValidatorIn{}
 				require.NoError(t, proto.Unmarshal(msg.Payload(), vIn))
-				t.Logf("vIn: %#v", vIn)
+				t.Logf("vIn: %+v", vIn)
 
 				// Normalize generated trace ID.
 				lTest.res.Point.TraceId = vIn.Point.TraceId
@@ -100,10 +100,10 @@ func TestParseMessages(t *testing.T) {
 				// Testify does not currently support protobuf equality:
 				// https://github.com/stretchr/testify/issues/758
 				if !proto.Equal(lTest.res, vIn) {
-					t.Fatalf("Expected, actual: %#v, %#v", lTest.res, vIn)
+					t.Fatalf("\nExpect: %+v\nActual: %+v", lTest.res, vIn)
 				}
 			case <-time.After(5 * time.Second):
-				t.Error("Message timed out")
+				t.Fatal("Message timed out")
 			}
 		})
 	}
@@ -137,7 +137,7 @@ func TestParseMessagesError(t *testing.T) {
 
 			select {
 			case msg := <-globalParserSub.C():
-				t.Errorf("Received unexpected msg.Topic, msg.Payload: %v, %s",
+				t.Fatalf("Received unexpected msg.Topic, msg.Payload: %v, %s",
 					msg.Topic(), msg.Payload())
 			case <-time.After(500 * time.Millisecond):
 				// Successful timeout without publish (normally 0.25s).

--- a/internal/mqtt-ingestor/test/main_test.go
+++ b/internal/mqtt-ingestor/test/main_test.go
@@ -31,6 +31,7 @@ func TestMain(m *testing.M) {
 	cfg.NSQPubAddr = testConfig.NSQPubAddr
 	cfg.NSQPubTopic += "-test-" + random.String(10)
 	globalParserPubTopic = cfg.NSQPubTopic
+	log.Printf("TestMain cfg.NSQPubTopic: %v", cfg.NSQPubTopic)
 
 	// Set up MQTT client connection to publish test payloads.
 	var err error

--- a/internal/validator/test/main_test.go
+++ b/internal/validator/test/main_test.go
@@ -37,6 +37,7 @@ func TestMain(m *testing.M) {
 	cfg.NSQLookupAddrs = testConfig.NSQLookupAddrs
 	cfg.NSQSubTopic += "-test-" + random.String(10)
 	globalVInSubTopic = cfg.NSQSubTopic
+	log.Printf("TestMain cfg.NSQSubTopic: %v", cfg.NSQSubTopic)
 	// Use a unique channel for each test run. This prevents failed tests from
 	// interfering with the next run, but does require eventual cleaning.
 	cfg.NSQSubChannel = "validator-test-" + random.String(10)
@@ -44,6 +45,7 @@ func TestMain(m *testing.M) {
 	cfg.NSQPubAddr = testConfig.NSQPubAddr
 	cfg.NSQPubTopic += "-test-" + random.String(10)
 	globalVOutPubTopic = cfg.NSQPubTopic
+	log.Printf("TestMain cfg.NSQPubTopic: %v", cfg.NSQPubTopic)
 
 	// Set up NSQ queue to publish test payloads.
 	var err error

--- a/internal/validator/validator/validate.go
+++ b/internal/validator/validator/validate.go
@@ -53,6 +53,10 @@ func (val *Validator) validateMessages() {
 		logEntry = logEntry.WithStr("devID", dev.ID)
 
 		switch {
+		case vIn.Point.ValOneof == nil:
+			logEntry.Debugf("validateMessages missing value: %+v", vIn)
+			msg.Ack()
+			continue
 		case vIn.OrgId != dev.OrgID:
 			logEntry.Debugf("validateMessages invalid org ID: %+v", vIn)
 			msg.Ack()
@@ -87,7 +91,7 @@ func (val *Validator) validateMessages() {
 			continue
 		}
 		msg.Ack()
-		logEntry.Debugf("validateMessages published: %#v", vOut)
+		logEntry.Debugf("validateMessages published: %+v", vOut)
 
 		processCount++
 		if processCount%100 == 0 {

--- a/pkg/dao/datapoint/crudl.go
+++ b/pkg/dao/datapoint/crudl.go
@@ -1,0 +1,136 @@
+package datapoint
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgconn"
+	"github.com/thingspect/api/go/common"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+var (
+	ErrDuplicate = errors.New("datapoint: duplicate")
+	ErrBadFormat = errors.New("datapoint: bad format")
+)
+
+const createDataPoint = `
+INSERT INTO data_points (org_id, uniq_id, attr, int_val, fl64_val, str_val,
+bool_val, bytes_val, created_at, trace_id)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+`
+
+// Create creates a data point in the database.
+func (d *DAO) Create(ctx context.Context, point *common.DataPoint,
+	orgID string) error {
+	// Truncate timestamp to milliseconds for deduplication.
+	createdAt := point.Ts.AsTime().UTC().Truncate(time.Millisecond)
+
+	var intVal *int64
+	var fl64Val *float64
+	var strVal *string
+	var boolVal *bool
+	var bytesVal []byte
+
+	switch v := point.ValOneof.(type) {
+	case *common.DataPoint_IntVal:
+		intVal = &v.IntVal
+	case *common.DataPoint_Fl64Val:
+		fl64Val = &v.Fl64Val
+	case *common.DataPoint_StrVal:
+		strVal = &v.StrVal
+	case *common.DataPoint_BoolVal:
+		boolVal = &v.BoolVal
+	case *common.DataPoint_BytesVal:
+		bytesVal = v.BytesVal
+	}
+
+	_, err := d.pg.ExecContext(ctx, createDataPoint, orgID,
+		strings.ToLower(point.UniqId), point.Attr, intVal, fl64Val, strVal,
+		boolVal, bytesVal, createdAt, point.TraceId)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) {
+			switch pgErr.Code {
+			case "23505":
+				return fmt.Errorf("%w: %#v", ErrDuplicate, pgErr)
+			case "22001", "23514":
+				return fmt.Errorf("%w: %#v", ErrBadFormat, pgErr)
+			}
+		}
+		return err
+	}
+	return nil
+}
+
+const listDataPoints = `
+SELECT uniq_id, attr, int_val, fl64_val, str_val, bool_val, bytes_val,
+created_at, trace_id
+FROM data_points
+WHERE org_id = $1
+AND uniq_id = $2
+AND created_at >= $3
+AND created_at <= $4
+`
+
+// List retrieves all data points by org ID, UniqID, and start and end times
+// (inclusive).
+func (d *DAO) List(ctx context.Context, orgID, uniqID string, start,
+	end time.Time) ([]*common.DataPoint, error) {
+	var points []*common.DataPoint
+
+	rows, err := d.pg.QueryContext(ctx, listDataPoints, orgID, uniqID,
+		start.Truncate(time.Millisecond), end.Truncate(time.Millisecond))
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err = rows.Close(); err != nil {
+			log.Printf("List rows.Close: %v", err)
+		}
+	}()
+
+	for rows.Next() {
+		point := &common.DataPoint{}
+		var intVal *int64
+		var fl64Val *float64
+		var strVal *string
+		var boolVal *bool
+		var bytesVal []byte
+		var createdAt time.Time
+
+		if err = rows.Scan(&point.UniqId, &point.Attr, &intVal, &fl64Val,
+			&strVal, &boolVal, &bytesVal, &createdAt,
+			&point.TraceId); err != nil {
+			return nil, err
+		}
+
+		switch {
+		case intVal != nil:
+			point.ValOneof = &common.DataPoint_IntVal{IntVal: *intVal}
+		case fl64Val != nil:
+			point.ValOneof = &common.DataPoint_Fl64Val{Fl64Val: *fl64Val}
+		case strVal != nil:
+			point.ValOneof = &common.DataPoint_StrVal{StrVal: *strVal}
+		case boolVal != nil:
+			point.ValOneof = &common.DataPoint_BoolVal{BoolVal: *boolVal}
+		case bytesVal != nil:
+			point.ValOneof = &common.DataPoint_BytesVal{BytesVal: bytesVal}
+		}
+
+		point.Ts = timestamppb.New(createdAt)
+		points = append(points, point)
+	}
+
+	if err = rows.Close(); err != nil {
+		return nil, err
+	}
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+	return points, nil
+}

--- a/pkg/dao/datapoint/crudl_test.go
+++ b/pkg/dao/datapoint/crudl_test.go
@@ -1,0 +1,225 @@
+// +build !unit
+
+package datapoint
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/thingspect/api/go/common"
+	"github.com/thingspect/atlas/pkg/test/random"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestCreate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Create valid data points", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			inpPoint *common.DataPoint
+			inpOrgID string
+		}{
+			{&common.DataPoint{UniqId: random.String(16), Attr: "motion",
+				ValOneof: &common.DataPoint_IntVal{IntVal: 123},
+				Ts:       timestamppb.Now(), Token: uuid.New().String(),
+				TraceId: uuid.New().String()}, uuid.New().String()},
+			{&common.DataPoint{UniqId: random.String(16), Attr: "temp",
+				ValOneof: &common.DataPoint_Fl64Val{Fl64Val: 9.3},
+				Ts:       timestamppb.Now(), Token: uuid.New().String(),
+				TraceId: uuid.New().String()}, uuid.New().String()},
+			{&common.DataPoint{UniqId: random.String(16), Attr: "power",
+				ValOneof: &common.DataPoint_StrVal{StrVal: "batt"},
+				Ts:       timestamppb.Now(), Token: uuid.New().String(),
+				TraceId: uuid.New().String()}, uuid.New().String()},
+			{&common.DataPoint{UniqId: random.String(16), Attr: "leak",
+				ValOneof: &common.DataPoint_BoolVal{
+					BoolVal: []bool{true, false}[random.Intn(2)]},
+				Ts: timestamppb.Now(), Token: uuid.New().String(),
+				TraceId: uuid.New().String()}, uuid.New().String()},
+			{&common.DataPoint{UniqId: random.String(16), Attr: "raw",
+				ValOneof: &common.DataPoint_BytesVal{BytesVal: []byte{0x00}},
+				Ts:       timestamppb.Now(), Token: uuid.New().String(),
+				TraceId: uuid.New().String()}, uuid.New().String()},
+		}
+
+		for _, test := range tests {
+			lTest := test
+
+			t.Run(fmt.Sprintf("Can create %+v", lTest), func(t *testing.T) {
+				t.Parallel()
+
+				ctx, cancel := context.WithTimeout(context.Background(),
+					2*time.Second)
+				defer cancel()
+
+				err := globalDPDAO.Create(ctx, lTest.inpPoint, lTest.inpOrgID)
+				t.Logf("err: %v", err)
+				require.NoError(t, err)
+			})
+		}
+	})
+
+	t.Run("Create invalid data point", func(t *testing.T) {
+		t.Parallel()
+
+		orgID := uuid.New().String()
+
+		tests := []struct {
+			inpPoint *common.DataPoint
+			err      error
+		}{
+			{&common.DataPoint{UniqId: random.String(41), Attr: "motion",
+				ValOneof: &common.DataPoint_IntVal{IntVal: 123},
+				Ts:       timestamppb.Now(), Token: uuid.New().String(),
+				TraceId: uuid.New().String()}, ErrBadFormat},
+			{&common.DataPoint{UniqId: random.String(16), Attr: "raw",
+				ValOneof: &common.DataPoint_BytesVal{
+					BytesVal: []byte(random.String(256))},
+				Ts: timestamppb.Now(), Token: uuid.New().String(),
+				TraceId: uuid.New().String()}, ErrBadFormat},
+		}
+
+		for _, test := range tests {
+			lTest := test
+
+			t.Run(fmt.Sprintf("Cannot create %+v", lTest), func(t *testing.T) {
+				t.Parallel()
+
+				ctx, cancel := context.WithTimeout(context.Background(),
+					2*time.Second)
+				defer cancel()
+
+				err := globalDPDAO.Create(ctx, lTest.inpPoint, orgID)
+				t.Logf("err: %#v", err)
+				if !errors.Is(err, lTest.err) {
+					t.Fatalf("\nExpect: %#v\nActual: %#v", lTest.err, err)
+				}
+			})
+		}
+	})
+
+	t.Run("Dedupe data point", func(t *testing.T) {
+		t.Parallel()
+
+		point := &common.DataPoint{UniqId: random.String(16), Attr: "motion",
+			ValOneof: &common.DataPoint_IntVal{IntVal: 123},
+			Ts:       timestamppb.Now(), Token: uuid.New().String(),
+			TraceId: uuid.New().String()}
+		orgID := uuid.New().String()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		defer cancel()
+
+		err := globalDPDAO.Create(ctx, point, orgID)
+		t.Logf("err: %#v", err)
+		require.NoError(t, err)
+
+		err = globalDPDAO.Create(ctx, point, orgID)
+		t.Logf("err: %#v", err)
+		if !errors.Is(err, ErrDuplicate) {
+			t.Fatalf("\nExpect: %#v\nActual: %#v", ErrDuplicate, err)
+		}
+	})
+}
+
+func TestListDevices(t *testing.T) {
+	t.Parallel()
+
+	t.Run("List data points by valid org ID", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			inpPoint *common.DataPoint
+			inpOrgID string
+		}{
+			{&common.DataPoint{UniqId: random.String(16), Attr: "motion",
+				ValOneof: &common.DataPoint_IntVal{IntVal: 123},
+				Ts:       timestamppb.Now(), Token: uuid.New().String(),
+				TraceId: uuid.New().String()}, uuid.New().String()},
+			{&common.DataPoint{UniqId: random.String(16), Attr: "temp",
+				ValOneof: &common.DataPoint_Fl64Val{Fl64Val: 9.3},
+				Ts:       timestamppb.Now(), Token: uuid.New().String(),
+				TraceId: uuid.New().String()}, uuid.New().String()},
+			{&common.DataPoint{UniqId: random.String(16), Attr: "power",
+				ValOneof: &common.DataPoint_StrVal{StrVal: "batt"},
+				Ts:       timestamppb.Now(), Token: uuid.New().String(),
+				TraceId: uuid.New().String()}, uuid.New().String()},
+			{&common.DataPoint{UniqId: random.String(16), Attr: "leak",
+				ValOneof: &common.DataPoint_BoolVal{
+					BoolVal: []bool{true, false}[random.Intn(2)]},
+				Ts: timestamppb.Now(), Token: uuid.New().String(),
+				TraceId: uuid.New().String()}, uuid.New().String()},
+			{&common.DataPoint{UniqId: random.String(16), Attr: "raw",
+				ValOneof: &common.DataPoint_BytesVal{BytesVal: []byte{0x00}},
+				Ts:       timestamppb.Now(), Token: uuid.New().String(),
+				TraceId: uuid.New().String()}, uuid.New().String()},
+		}
+
+		for _, test := range tests {
+			lTest := test
+
+			t.Run(fmt.Sprintf("Can create %+v", lTest), func(t *testing.T) {
+				t.Parallel()
+
+				ctx, cancel := context.WithTimeout(context.Background(),
+					4*time.Second)
+				defer cancel()
+
+				err := globalDPDAO.Create(ctx, lTest.inpPoint, lTest.inpOrgID)
+				t.Logf("err: %v", err)
+				require.NoError(t, err)
+
+				listPoints, err := globalDPDAO.List(ctx, lTest.inpOrgID,
+					lTest.inpPoint.UniqId, lTest.inpPoint.Ts.AsTime(),
+					lTest.inpPoint.Ts.AsTime())
+				t.Logf("listPoints, err: %+v, %v", listPoints, err)
+				require.NoError(t, err)
+				require.Len(t, listPoints, 1)
+
+				// Normalize token.
+				listPoints[0].Token = lTest.inpPoint.Token
+				// Normalize timestamp.
+				lTest.inpPoint.Ts = timestamppb.New(
+					lTest.inpPoint.Ts.AsTime().Truncate(time.Millisecond))
+
+				// Testify does not currently support protobuf equality:
+				// https://github.com/stretchr/testify/issues/758
+				if !proto.Equal(lTest.inpPoint, listPoints[0]) {
+					t.Fatalf("\nExpect: %+v\nActual: %+v", lTest.inpPoint,
+						listPoints[0])
+				}
+			})
+		}
+	})
+
+	t.Run("Lists are isolated by org ID", func(t *testing.T) {
+		t.Parallel()
+
+		point := &common.DataPoint{UniqId: random.String(16), Attr: "motion",
+			ValOneof: &common.DataPoint_IntVal{IntVal: 123},
+			Ts:       timestamppb.Now(), Token: uuid.New().String(),
+			TraceId: uuid.New().String()}
+		orgID := uuid.New().String()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		defer cancel()
+
+		err := globalDPDAO.Create(ctx, point, orgID)
+		t.Logf("err: %#v", err)
+		require.NoError(t, err)
+
+		listPoints, err := globalDPDAO.List(ctx, uuid.New().String(),
+			point.UniqId, point.Ts.AsTime(), point.Ts.AsTime())
+		t.Logf("listPoints, err: %+v, %v", listPoints, err)
+		require.NoError(t, err)
+		require.Len(t, listPoints, 0)
+	})
+}

--- a/pkg/dao/datapoint/dao.go
+++ b/pkg/dao/datapoint/dao.go
@@ -1,0 +1,19 @@
+// Package datapoint provides functions to create and query data points in the
+// database.
+package datapoint
+
+import (
+	"database/sql"
+)
+
+// DAO contains functions to create and query data points in the database.
+type DAO struct {
+	pg *sql.DB
+}
+
+// NewDAO instantiates and returns a new DAO.
+func NewDAO(pg *sql.DB) *DAO {
+	return &DAO{
+		pg: pg,
+	}
+}

--- a/pkg/dao/datapoint/main_test.go
+++ b/pkg/dao/datapoint/main_test.go
@@ -1,0 +1,28 @@
+// +build !unit
+
+package datapoint
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	"github.com/thingspect/atlas/pkg/postgres"
+	"github.com/thingspect/atlas/pkg/test/config"
+)
+
+var globalDPDAO *DAO
+
+func TestMain(m *testing.M) {
+	// Set up Config.
+	testConfig := config.New()
+
+	// Set up database connection.
+	pg, err := postgres.New(testConfig.PgURI)
+	if err != nil {
+		log.Fatalf("TestMain postgres.New: %v", err)
+	}
+	globalDPDAO = NewDAO(pg)
+
+	os.Exit(m.Run())
+}

--- a/pkg/postgres/postgres_test.go
+++ b/pkg/postgres/postgres_test.go
@@ -37,7 +37,7 @@ func TestNew(t *testing.T) {
 			t.Parallel()
 
 			res, err := New(lTest.inp)
-			t.Logf("res, err: %+v, %v", res, err)
+			t.Logf("res, err: %+v, %#v", res, err)
 			if lTest.err == "" {
 				require.NotNil(t, res)
 			} else {

--- a/pkg/queue/fake_test.go
+++ b/pkg/queue/fake_test.go
@@ -42,7 +42,7 @@ func TestFakeSubscribe(t *testing.T) {
 		require.Equal(t, topic, msg.Topic())
 		require.Equal(t, payload, msg.Payload())
 	case <-time.After(2 * time.Second):
-		t.Error("Message timed out")
+		t.Fatal("Message timed out")
 	}
 }
 

--- a/pkg/queue/mqtt_test.go
+++ b/pkg/queue/mqtt_test.go
@@ -89,7 +89,7 @@ func TestMQTTSubscribe(t *testing.T) {
 		require.Equal(t, topic, msg.Topic())
 		require.Equal(t, payload, msg.Payload())
 	case <-time.After(5 * time.Second):
-		t.Error("Message timed out")
+		t.Fatal("Message timed out")
 	}
 }
 
@@ -120,7 +120,7 @@ func TestMQTTUnsubscribe(t *testing.T) {
 		require.Nil(t, msg)
 		require.False(t, ok)
 	case <-time.After(5 * time.Second):
-		t.Error("Message timed out")
+		t.Fatal("Message timed out")
 	}
 }
 

--- a/pkg/queue/nsq_test.go
+++ b/pkg/queue/nsq_test.go
@@ -96,7 +96,7 @@ func TestNSQSubscribeLookup(t *testing.T) {
 		require.Equal(t, topic, msg.Topic())
 		require.Equal(t, payload, msg.Payload())
 	case <-time.After(5 * time.Second):
-		t.Error("Message timed out")
+		t.Fatal("Message timed out")
 	}
 }
 
@@ -125,7 +125,7 @@ func TestNSQSubscribePub(t *testing.T) {
 		require.Equal(t, topic, msg.Topic())
 		require.Equal(t, payload, msg.Payload())
 	case <-time.After(5 * time.Second):
-		t.Error("Message timed out")
+		t.Fatal("Message timed out")
 	}
 }
 
@@ -156,7 +156,7 @@ func TestNSQUnsubscribe(t *testing.T) {
 		require.Nil(t, msg)
 		require.False(t, ok)
 	case <-time.After(5 * time.Second):
-		t.Error("Message timed out")
+		t.Fatal("Message timed out")
 	}
 }
 
@@ -187,7 +187,7 @@ func TestNSQRequeue(t *testing.T) {
 		require.Equal(t, topic, msg.Topic())
 		require.Equal(t, payload, msg.Payload())
 	case <-time.After(5 * time.Second):
-		t.Error("Requeue message timed out")
+		t.Fatal("Requeue message timed out")
 	}
 
 	select {
@@ -197,7 +197,7 @@ func TestNSQRequeue(t *testing.T) {
 		require.Equal(t, topic, msg.Topic())
 		require.Equal(t, payload, msg.Payload())
 	case <-time.After(10 * time.Second):
-		t.Error("Ack message timed out")
+		t.Fatal("Ack message timed out")
 	}
 }
 

--- a/pkg/test/random/string_test.go
+++ b/pkg/test/random/string_test.go
@@ -12,7 +12,7 @@ import (
 func TestString(t *testing.T) {
 	t.Parallel()
 
-	for i := 0; i < 10; i++ {
+	for i := 5; i < 15; i++ {
 		lTest := i
 
 		t.Run(fmt.Sprintf("Can generate %v", lTest), func(t *testing.T) {
@@ -24,10 +24,7 @@ func TestString(t *testing.T) {
 
 			require.Len(t, s1, lTest)
 			require.Len(t, s2, lTest)
-			// Collisions on 1- and 2-character strings are common.
-			if lTest > 2 {
-				require.NotEqual(t, s1, s2)
-			}
+			require.NotEqual(t, s1, s2)
 		})
 	}
 }

--- a/vendor/gopkg.in/yaml.v3/.travis.yml
+++ b/vendor/gopkg.in/yaml.v3/.travis.yml
@@ -11,6 +11,7 @@ go:
     - "1.11.x"
     - "1.12.x"
     - "1.13.x"
+    - "1.14.x"
     - "tip"
 
 go_import_path: gopkg.in/yaml.v3

--- a/vendor/gopkg.in/yaml.v3/apic.go
+++ b/vendor/gopkg.in/yaml.v3/apic.go
@@ -108,6 +108,7 @@ func yaml_emitter_initialize(emitter *yaml_emitter_t) {
 		raw_buffer: make([]byte, 0, output_raw_buffer_size),
 		states:     make([]yaml_emitter_state_t, 0, initial_stack_size),
 		events:     make([]yaml_event_t, 0, initial_queue_size),
+		best_width: -1,
 	}
 }
 

--- a/vendor/gopkg.in/yaml.v3/decode.go
+++ b/vendor/gopkg.in/yaml.v3/decode.go
@@ -35,6 +35,7 @@ type parser struct {
 	doc      *Node
 	anchors  map[string]*Node
 	doneInit bool
+	textless bool
 }
 
 func newParser(b []byte) *parser {
@@ -108,14 +109,18 @@ func (p *parser) peek() yaml_event_type_t {
 func (p *parser) fail() {
 	var where string
 	var line int
-	if p.parser.problem_mark.line != 0 {
+	if p.parser.context_mark.line != 0 {
+		line = p.parser.context_mark.line
+		// Scanner errors don't iterate line before returning error
+		if p.parser.error == yaml_SCANNER_ERROR {
+			line++
+		}
+	} else if p.parser.problem_mark.line != 0 {
 		line = p.parser.problem_mark.line
 		// Scanner errors don't iterate line before returning error
 		if p.parser.error == yaml_SCANNER_ERROR {
 			line++
 		}
-	} else if p.parser.context_mark.line != 0 {
-		line = p.parser.context_mark.line
 	}
 	if line != 0 {
 		where = "line " + strconv.Itoa(line) + ": "
@@ -169,17 +174,20 @@ func (p *parser) node(kind Kind, defaultTag, tag, value string) *Node {
 	} else if kind == ScalarNode {
 		tag, _ = resolve("", value)
 	}
-	return &Node{
-		Kind:        kind,
-		Tag:         tag,
-		Value:       value,
-		Style:       style,
-		Line:        p.event.start_mark.line + 1,
-		Column:      p.event.start_mark.column + 1,
-		HeadComment: string(p.event.head_comment),
-		LineComment: string(p.event.line_comment),
-		FootComment: string(p.event.foot_comment),
+	n := &Node{
+		Kind:  kind,
+		Tag:   tag,
+		Value: value,
+		Style: style,
 	}
+	if !p.textless {
+		n.Line = p.event.start_mark.line + 1
+		n.Column = p.event.start_mark.column + 1
+		n.HeadComment = string(p.event.head_comment)
+		n.LineComment = string(p.event.line_comment)
+		n.FootComment = string(p.event.foot_comment)
+	}
+	return n
 }
 
 func (p *parser) parseChild(parent *Node) *Node {
@@ -391,7 +399,7 @@ func (d *decoder) callObsoleteUnmarshaler(n *Node, u obsoleteUnmarshaler) (good 
 //
 // If n holds a null value, prepare returns before doing anything.
 func (d *decoder) prepare(n *Node, out reflect.Value) (newout reflect.Value, unmarshaled, good bool) {
-	if n.ShortTag() == nullTag {
+	if n.ShortTag() == nullTag || n.Kind == 0 && n.IsZero() {
 		return out, false, false
 	}
 	again := true
@@ -497,8 +505,13 @@ func (d *decoder) unmarshal(n *Node, out reflect.Value) (good bool) {
 		good = d.mapping(n, out)
 	case SequenceNode:
 		good = d.sequence(n, out)
+	case 0:
+		if n.IsZero() {
+			return d.null(out)
+		}
+		fallthrough
 	default:
-		panic("internal error: unknown node kind: " + strconv.Itoa(int(n.Kind)))
+		failf("cannot decode node with unknown kind %d", n.Kind)
 	}
 	return good
 }
@@ -533,6 +546,17 @@ func resetMap(out reflect.Value) {
 	}
 }
 
+func (d *decoder) null(out reflect.Value) bool {
+	if out.CanAddr() {
+		switch out.Kind() {
+		case reflect.Interface, reflect.Ptr, reflect.Map, reflect.Slice:
+			out.Set(reflect.Zero(out.Type()))
+			return true
+		}
+	}
+	return false
+}
+
 func (d *decoder) scalar(n *Node, out reflect.Value) bool {
 	var tag string
 	var resolved interface{}
@@ -550,14 +574,7 @@ func (d *decoder) scalar(n *Node, out reflect.Value) bool {
 		}
 	}
 	if resolved == nil {
-		if out.CanAddr() {
-			switch out.Kind() {
-			case reflect.Interface, reflect.Ptr, reflect.Map, reflect.Slice:
-				out.Set(reflect.Zero(out.Type()))
-				return true
-			}
-		}
-		return false
+		return d.null(out)
 	}
 	if resolvedv := reflect.ValueOf(resolved); out.Type() == resolvedv.Type() {
 		// We've resolved to exactly the type we want, so use that.

--- a/vendor/gopkg.in/yaml.v3/parserc.go
+++ b/vendor/gopkg.in/yaml.v3/parserc.go
@@ -648,6 +648,10 @@ func yaml_parser_parse_node(parser *yaml_parser_t, event *yaml_event_t, block, i
 			implicit:   implicit,
 			style:      yaml_style_t(yaml_BLOCK_MAPPING_STYLE),
 		}
+		if parser.stem_comment != nil {
+			event.head_comment = parser.stem_comment
+			parser.stem_comment = nil
+		}
 		return true
 	}
 	if len(anchor) > 0 || len(tag) > 0 {
@@ -694,24 +698,12 @@ func yaml_parser_parse_block_sequence_entry(parser *yaml_parser_t, event *yaml_e
 
 	if token.typ == yaml_BLOCK_ENTRY_TOKEN {
 		mark := token.end_mark
-		prior_head := len(parser.head_comment)
+		prior_head_len := len(parser.head_comment)
 		skip_token(parser)
+		yaml_parser_split_stem_comment(parser, prior_head_len)
 		token = peek_token(parser)
 		if token == nil {
 			return false
-		}
-		if prior_head > 0 && token.typ == yaml_BLOCK_SEQUENCE_START_TOKEN {
-			// [Go] It's a sequence under a sequence entry, so the former head comment
-			//      is for the list itself, not the first list item under it.
-			parser.stem_comment = parser.head_comment[:prior_head]
-			if len(parser.head_comment) == prior_head {
-				parser.head_comment = nil
-			} else {
-				// Copy suffix to prevent very strange bugs if someone ever appends
-				// further bytes to the prefix in the stem_comment slice above.
-				parser.head_comment = append([]byte(nil), parser.head_comment[prior_head+1:]...)
-			}
-
 		}
 		if token.typ != yaml_BLOCK_ENTRY_TOKEN && token.typ != yaml_BLOCK_END_TOKEN {
 			parser.states = append(parser.states, yaml_PARSE_BLOCK_SEQUENCE_ENTRY_STATE)
@@ -754,7 +746,9 @@ func yaml_parser_parse_indentless_sequence_entry(parser *yaml_parser_t, event *y
 
 	if token.typ == yaml_BLOCK_ENTRY_TOKEN {
 		mark := token.end_mark
+		prior_head_len := len(parser.head_comment)
 		skip_token(parser)
+		yaml_parser_split_stem_comment(parser, prior_head_len)
 		token = peek_token(parser)
 		if token == nil {
 			return false
@@ -778,6 +772,32 @@ func yaml_parser_parse_indentless_sequence_entry(parser *yaml_parser_t, event *y
 		end_mark:   token.start_mark, // [Go] Shouldn't this be token.end_mark?
 	}
 	return true
+}
+
+// Split stem comment from head comment.
+//
+// When a sequence or map is found under a sequence entry, the former head comment
+// is assigned to the underlying sequence or map as a whole, not the individual
+// sequence or map entry as would be expected otherwise. To handle this case the
+// previous head comment is moved aside as the stem comment.
+func yaml_parser_split_stem_comment(parser *yaml_parser_t, stem_len int) {
+	if stem_len == 0 {
+		return
+	}
+
+	token := peek_token(parser)
+	if token.typ != yaml_BLOCK_SEQUENCE_START_TOKEN && token.typ != yaml_BLOCK_MAPPING_START_TOKEN {
+		return
+	}
+
+	parser.stem_comment = parser.head_comment[:stem_len]
+	if len(parser.head_comment) == stem_len {
+		parser.head_comment = nil
+	} else {
+		// Copy suffix to prevent very strange bugs if someone ever appends
+		// further bytes to the prefix in the stem_comment slice above.
+		parser.head_comment = append([]byte(nil), parser.head_comment[stem_len+1:]...)
+	}
 }
 
 // Parse the productions:

--- a/vendor/gopkg.in/yaml.v3/scannerc.go
+++ b/vendor/gopkg.in/yaml.v3/scannerc.go
@@ -749,6 +749,11 @@ func yaml_parser_fetch_next_token(parser *yaml_parser_t) (ok bool) {
 		if !ok {
 			return
 		}
+		if len(parser.tokens) > 0 && parser.tokens[len(parser.tokens)-1].typ == yaml_BLOCK_ENTRY_TOKEN {
+			// Sequence indicators alone have no line comments. It becomes
+			// a head comment for whatever follows.
+			return
+		}
 		if !yaml_parser_scan_line_comment(parser, comment_mark) {
 			ok = false
 			return
@@ -2856,13 +2861,12 @@ func yaml_parser_scan_line_comment(parser *yaml_parser_t, token_mark yaml_mark_t
 						return false
 					}
 					skip_line(parser)
-				} else {
-					if parser.mark.index >= seen {
-						if len(text) == 0 {
-							start_mark = parser.mark
-						}
-						text = append(text, parser.buffer[parser.buffer_pos])
+				} else if parser.mark.index >= seen {
+					if len(text) == 0 {
+						start_mark = parser.mark
 					}
+					text = read(parser, text)
+				} else {
 					skip(parser)
 				}
 			}
@@ -2999,10 +3003,9 @@ func yaml_parser_scan_comments(parser *yaml_parser_t, scan_mark yaml_mark_t) boo
 					return false
 				}
 				skip_line(parser)
+			} else if parser.mark.index >= seen {
+				text = read(parser, text)
 			} else {
-				if parser.mark.index >= seen {
-					text = append(text, parser.buffer[parser.buffer_pos])
-				}
 				skip(parser)
 			}
 		}

--- a/vendor/gopkg.in/yaml.v3/yamlh.go
+++ b/vendor/gopkg.in/yaml.v3/yamlh.go
@@ -787,6 +787,8 @@ type yaml_emitter_t struct {
 	foot_comment []byte
 	tail_comment []byte
 
+	key_line_comment []byte
+
 	// Dumper stuff
 
 	opened bool // If the stream was already opened?

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -21,6 +21,7 @@ github.com/gorilla/websocket
 # github.com/jackc/chunkreader/v2 v2.0.1
 github.com/jackc/chunkreader/v2
 # github.com/jackc/pgconn v1.8.0
+## explicit
 github.com/jackc/pgconn
 github.com/jackc/pgconn/internal/ctxwatch
 github.com/jackc/pgconn/stmtcache
@@ -63,10 +64,10 @@ github.com/stretchr/testify/require
 ## explicit
 github.com/thingspect/api/go/common
 github.com/thingspect/api/go/mqtt
-# golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c
+# golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9
 ## explicit
 golang.org/x/crypto/pbkdf2
-# golang.org/x/net v0.0.0-20201207224615-747e23833adb
+# golang.org/x/net v0.0.0-20201209123823-ac852fbbde11
 ## explicit
 golang.org/x/net/internal/socks
 golang.org/x/net/proxy
@@ -120,5 +121,6 @@ google.golang.org/protobuf/reflect/protoregistry
 google.golang.org/protobuf/runtime/protoiface
 google.golang.org/protobuf/runtime/protoimpl
 google.golang.org/protobuf/types/known/timestamppb
-# gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
+# gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
+## explicit
 gopkg.in/yaml.v3


### PR DESCRIPTION
- Add migration, DAO, cmd, config, service, unit and integration tests.
- Add an additional validator check for a `common.DataPoint` with missing value.
- Sync `vendor/` for updated dependencies.
- All test variations pass.
