### PR TITLE
Unify test timeouts for contexts and selects

### DIFF
--- a/internal/accumulator/test/accumulator_test.go
+++ b/internal/accumulator/test/accumulator_test.go
@@ -58,7 +58,7 @@ func TestAccumulateMessages(t *testing.T) {
 			time.Sleep(2 * time.Second)
 
 			ctx, cancel := context.WithTimeout(context.Background(),
-				2*time.Second)
+				testTimeout)
 			defer cancel()
 
 			listPoints, err := globalDPDAO.List(ctx, lTest.inp.OrgId,
@@ -87,7 +87,7 @@ func TestAccumulateMessages(t *testing.T) {
 func TestAccumulateMessagesDuplicate(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
 	duplicateVOut := &message.ValidatorOut{Point: &common.DataPoint{
@@ -106,7 +106,7 @@ func TestAccumulateMessagesDuplicate(t *testing.T) {
 	require.NoError(t, globalVOutQueue.Publish(globalVOutSubTopic, bVOut))
 	time.Sleep(2 * time.Second)
 
-	ctx, cancel = context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
 	listPoints, err := globalDPDAO.List(ctx, duplicateVOut.OrgId,

--- a/internal/accumulator/test/main_test.go
+++ b/internal/accumulator/test/main_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/thingspect/atlas/internal/accumulator/accumulator"
 	"github.com/thingspect/atlas/internal/accumulator/config"
@@ -15,6 +16,8 @@ import (
 	testconfig "github.com/thingspect/atlas/pkg/test/config"
 	"github.com/thingspect/atlas/pkg/test/random"
 )
+
+const testTimeout = 2 * time.Second
 
 var (
 	globalVOutSubTopic string

--- a/internal/api/api/status_code_test.go
+++ b/internal/api/api/status_code_test.go
@@ -15,6 +15,8 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
+const testTimeout = 2 * time.Second
+
 func TestStatusCode(t *testing.T) {
 	t.Parallel()
 
@@ -35,7 +37,7 @@ func TestStatusCode(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(runtime.NewServerMetadataContext(
 			context.Background(), runtime.ServerMetadata{HeaderMD: mdHeader}),
-			2*time.Second)
+			testTimeout)
 		defer cancel()
 
 		err := statusCode(ctx, respWriter, nil)
@@ -60,7 +62,7 @@ func TestStatusCode(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(runtime.NewServerMetadataContext(
 			context.Background(), runtime.ServerMetadata{HeaderMD: mdHeader}),
-			2*time.Second)
+			testTimeout)
 		defer cancel()
 
 		err := statusCode(ctx, respWriter, nil)
@@ -83,7 +85,7 @@ func TestStatusCode(t *testing.T) {
 		defer ctrl.Finish()
 		respWriter := NewMockResponseWriter(ctrl)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		err := statusCode(ctx, respWriter, nil)
@@ -109,7 +111,7 @@ func TestStatusCode(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(runtime.NewServerMetadataContext(
 			context.Background(), runtime.ServerMetadata{HeaderMD: mdHeader}),
-			2*time.Second)
+			testTimeout)
 		defer cancel()
 
 		err := statusCode(ctx, respWriter, nil)

--- a/internal/api/interceptor/auth_test.go
+++ b/internal/api/interceptor/auth_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/rand"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -62,7 +61,7 @@ func TestAuth(t *testing.T) {
 			t.Parallel()
 
 			ctx, cancel := context.WithTimeout(context.Background(),
-				2*time.Second)
+				testTimeout)
 			defer cancel()
 			if lTest.inpMD != nil {
 				ctx = metadata.NewIncomingContext(ctx,

--- a/internal/api/interceptor/log_test.go
+++ b/internal/api/interceptor/log_test.go
@@ -15,6 +15,8 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
+const testTimeout = 2 * time.Second
+
 func TestLog(t *testing.T) {
 	t.Parallel()
 
@@ -45,7 +47,7 @@ func TestLog(t *testing.T) {
 			t.Parallel()
 
 			ctx, cancel := context.WithTimeout(context.Background(),
-				2*time.Second)
+				testTimeout)
 			defer cancel()
 			ctx = metadata.NewIncomingContext(ctx,
 				metadata.Pairs(lTest.inpMD...))

--- a/internal/api/interceptor/validate_test.go
+++ b/internal/api/interceptor/validate_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/thingspect/atlas/pkg/test/random"
@@ -51,7 +50,7 @@ func TestValidate(t *testing.T) {
 			t.Parallel()
 
 			ctx, cancel := context.WithTimeout(context.Background(),
-				2*time.Second)
+				testTimeout)
 			defer cancel()
 
 			handler := func(ctx context.Context, req interface{}) (interface{},

--- a/internal/api/service/datapoint_test.go
+++ b/internal/api/service/datapoint_test.go
@@ -42,7 +42,7 @@ func TestPublishDataPoints(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: orgID,
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		dpSvc := NewDataPoint(pubQueue, pubTopic, nil)
@@ -71,7 +71,7 @@ func TestPublishDataPoints(t *testing.T) {
 				t.Fatalf("\nExpect: %+v\nActual: %+v", &message.ValidatorIn{
 					Point: point, OrgId: orgID, SkipToken: true}, vIn)
 			}
-		case <-time.After(2 * time.Second):
+		case <-time.After(testTimeout):
 			t.Fatal("Message timed out")
 		}
 	})
@@ -90,7 +90,7 @@ func TestPublishDataPoints(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: orgID,
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		dpSvc := NewDataPoint(pubQueue, pubTopic, nil)
@@ -123,7 +123,7 @@ func TestPublishDataPoints(t *testing.T) {
 				t.Fatalf("\nExpect: %+v\nActual: %+v", &message.ValidatorIn{
 					Point: point, OrgId: orgID, SkipToken: true}, vIn)
 			}
-		case <-time.After(2 * time.Second):
+		case <-time.After(testTimeout):
 			t.Fatal("Message timed out")
 		}
 	})
@@ -137,7 +137,7 @@ func TestPublishDataPoints(t *testing.T) {
 		pubQueue := queue.NewFake()
 		pubTopic := "topic-" + random.String(10)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		dpSvc := NewDataPoint(pubQueue, pubTopic, nil)
@@ -158,7 +158,7 @@ func TestPublishDataPoints(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: uuid.NewString(),
-				Role: common.Role_VIEWER}), 2*time.Second)
+				Role: common.Role_VIEWER}), testTimeout)
 		defer cancel()
 
 		dpSvc := NewDataPoint(pubQueue, pubTopic, nil)
@@ -191,7 +191,7 @@ func TestListDataPoints(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: orgID,
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		dpSvc := NewDataPoint(nil, "", datapointer)
@@ -233,7 +233,7 @@ func TestListDataPoints(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: orgID,
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		dpSvc := NewDataPoint(nil, "", datapointer)
@@ -261,7 +261,7 @@ func TestListDataPoints(t *testing.T) {
 		defer ctrl.Finish()
 		datapointer := NewMockDataPointer(ctrl)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		dpSvc := NewDataPoint(nil, "", datapointer)
@@ -283,7 +283,7 @@ func TestListDataPoints(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: uuid.NewString(),
-				Role: common.Role_CONTACT}), 2*time.Second)
+				Role: common.Role_CONTACT}), testTimeout)
 		defer cancel()
 
 		dpSvc := NewDataPoint(nil, "", datapointer)
@@ -305,7 +305,7 @@ func TestListDataPoints(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: uuid.NewString(),
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		dpSvc := NewDataPoint(nil, "", datapointer)
@@ -334,7 +334,7 @@ func TestListDataPoints(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: "aaa",
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		dpSvc := NewDataPoint(nil, "", datapointer)
@@ -369,7 +369,7 @@ func TestLatestDataPoints(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: orgID,
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		dpSvc := NewDataPoint(nil, "", datapointer)
@@ -408,7 +408,7 @@ func TestLatestDataPoints(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: orgID,
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		dpSvc := NewDataPoint(nil, "", datapointer)
@@ -435,7 +435,7 @@ func TestLatestDataPoints(t *testing.T) {
 		defer ctrl.Finish()
 		datapointer := NewMockDataPointer(ctrl)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		dpSvc := NewDataPoint(nil, "", datapointer)
@@ -457,7 +457,7 @@ func TestLatestDataPoints(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: uuid.NewString(),
-				Role: common.Role_CONTACT}), 2*time.Second)
+				Role: common.Role_CONTACT}), testTimeout)
 		defer cancel()
 
 		dpSvc := NewDataPoint(nil, "", datapointer)
@@ -482,7 +482,7 @@ func TestLatestDataPoints(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: "aaa",
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		dpSvc := NewDataPoint(nil, "", datapointer)

--- a/internal/api/service/device_test.go
+++ b/internal/api/service/device_test.go
@@ -38,7 +38,7 @@ func TestCreateDevice(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: dev.OrgId,
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		devSvc := NewDevice(devicer)
@@ -61,7 +61,7 @@ func TestCreateDevice(t *testing.T) {
 		defer ctrl.Finish()
 		devicer := NewMockDevicer(ctrl)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		devSvc := NewDevice(devicer)
@@ -81,7 +81,7 @@ func TestCreateDevice(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: uuid.NewString(),
-				Role: common.Role_VIEWER}), 2*time.Second)
+				Role: common.Role_VIEWER}), testTimeout)
 		defer cancel()
 
 		devSvc := NewDevice(devicer)
@@ -107,7 +107,7 @@ func TestCreateDevice(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: dev.OrgId,
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		devSvc := NewDevice(devicer)
@@ -137,7 +137,7 @@ func TestGetDevice(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: dev.OrgId,
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		devSvc := NewDevice(devicer)
@@ -159,7 +159,7 @@ func TestGetDevice(t *testing.T) {
 		defer ctrl.Finish()
 		devicer := NewMockDevicer(ctrl)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		devSvc := NewDevice(devicer)
@@ -179,7 +179,7 @@ func TestGetDevice(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: uuid.NewString(),
-				Role: common.Role_CONTACT}), 2*time.Second)
+				Role: common.Role_CONTACT}), testTimeout)
 		defer cancel()
 
 		devSvc := NewDevice(devicer)
@@ -202,7 +202,7 @@ func TestGetDevice(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: uuid.NewString(),
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		devSvc := NewDevice(devicer)
@@ -230,7 +230,7 @@ func TestUpdateDevice(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: dev.OrgId,
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		devSvc := NewDevice(devicer)
@@ -265,7 +265,7 @@ func TestUpdateDevice(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: dev.OrgId,
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		devSvc := NewDevice(devicer)
@@ -289,7 +289,7 @@ func TestUpdateDevice(t *testing.T) {
 		defer ctrl.Finish()
 		devicer := NewMockDevicer(ctrl)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		devSvc := NewDevice(devicer)
@@ -309,7 +309,7 @@ func TestUpdateDevice(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: uuid.NewString(),
-				Role: common.Role_VIEWER}), 2*time.Second)
+				Role: common.Role_VIEWER}), testTimeout)
 		defer cancel()
 
 		devSvc := NewDevice(devicer)
@@ -329,7 +329,7 @@ func TestUpdateDevice(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: uuid.NewString(),
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		devSvc := NewDevice(devicer)
@@ -352,7 +352,7 @@ func TestUpdateDevice(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: uuid.NewString(),
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		devSvc := NewDevice(devicer)
@@ -380,7 +380,7 @@ func TestUpdateDevice(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: orgID,
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		devSvc := NewDevice(devicer)
@@ -404,7 +404,7 @@ func TestUpdateDevice(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: dev.OrgId,
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		devSvc := NewDevice(devicer)
@@ -432,7 +432,7 @@ func TestUpdateDevice(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: dev.OrgId,
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		devSvc := NewDevice(devicer)
@@ -460,7 +460,7 @@ func TestDeleteDevice(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: uuid.NewString(),
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		devSvc := NewDevice(devicer)
@@ -477,7 +477,7 @@ func TestDeleteDevice(t *testing.T) {
 		defer ctrl.Finish()
 		devicer := NewMockDevicer(ctrl)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		devSvc := NewDevice(devicer)
@@ -496,7 +496,7 @@ func TestDeleteDevice(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: uuid.NewString(),
-				Role: common.Role_VIEWER}), 2*time.Second)
+				Role: common.Role_VIEWER}), testTimeout)
 		defer cancel()
 
 		devSvc := NewDevice(devicer)
@@ -518,7 +518,7 @@ func TestDeleteDevice(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: uuid.NewString(),
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		devSvc := NewDevice(devicer)
@@ -552,7 +552,7 @@ func TestListDevices(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: orgID,
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		devSvc := NewDevice(devicer)
@@ -594,7 +594,7 @@ func TestListDevices(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: orgID,
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		devSvc := NewDevice(devicer)
@@ -621,7 +621,7 @@ func TestListDevices(t *testing.T) {
 		defer ctrl.Finish()
 		devicer := NewMockDevicer(ctrl)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		devSvc := NewDevice(devicer)
@@ -640,7 +640,7 @@ func TestListDevices(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: uuid.NewString(),
-				Role: common.Role_CONTACT}), 2*time.Second)
+				Role: common.Role_CONTACT}), testTimeout)
 		defer cancel()
 
 		devSvc := NewDevice(devicer)
@@ -659,7 +659,7 @@ func TestListDevices(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: uuid.NewString(),
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		devSvc := NewDevice(devicer)
@@ -683,7 +683,7 @@ func TestListDevices(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: "aaa",
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		devSvc := NewDevice(devicer)
@@ -715,7 +715,7 @@ func TestListDevices(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: orgID,
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		devSvc := NewDevice(devicer)

--- a/internal/api/service/main_test.go
+++ b/internal/api/service/main_test.go
@@ -6,10 +6,13 @@ import (
 	"log"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/thingspect/atlas/pkg/crypto"
 	"github.com/thingspect/atlas/pkg/test/random"
 )
+
+const testTimeout = 2 * time.Second
 
 var (
 	globalPass string

--- a/internal/api/service/session_test.go
+++ b/internal/api/service/session_test.go
@@ -41,7 +41,7 @@ func TestLogin(t *testing.T) {
 		_, err := rand.Read(key)
 		require.NoError(t, err)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		sessSvc := NewSession(userer, key)
@@ -73,7 +73,7 @@ func TestLogin(t *testing.T) {
 		_, err := rand.Read(key)
 		require.NoError(t, err)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		sessSvc := NewSession(userer, key)
@@ -103,7 +103,7 @@ func TestLogin(t *testing.T) {
 		_, err := rand.Read(key)
 		require.NoError(t, err)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		sessSvc := NewSession(userer, key)
@@ -133,7 +133,7 @@ func TestLogin(t *testing.T) {
 		_, err := rand.Read(key)
 		require.NoError(t, err)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		sessSvc := NewSession(userer, key)
@@ -164,7 +164,7 @@ func TestLogin(t *testing.T) {
 		_, err := rand.Read(key)
 		require.NoError(t, err)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		sessSvc := NewSession(userer, key)
@@ -191,7 +191,7 @@ func TestLogin(t *testing.T) {
 		userer.EXPECT().ReadByEmail(gomock.Any(), user.Email, org.Name).
 			Return(user, globalHash, nil).Times(1)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		sessSvc := NewSession(userer, nil)

--- a/internal/api/service/user_test.go
+++ b/internal/api/service/user_test.go
@@ -39,7 +39,7 @@ func TestCreateUser(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: user.OrgId,
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -62,7 +62,7 @@ func TestCreateUser(t *testing.T) {
 		defer ctrl.Finish()
 		userer := NewMockUserer(ctrl)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -82,7 +82,7 @@ func TestCreateUser(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: uuid.NewString(),
-				Role: common.Role_BUILDER}), 2*time.Second)
+				Role: common.Role_BUILDER}), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -107,7 +107,7 @@ func TestCreateUser(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: user.OrgId,
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -137,7 +137,7 @@ func TestGetUser(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: user.OrgId,
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -159,7 +159,7 @@ func TestGetUser(t *testing.T) {
 		defer ctrl.Finish()
 		userer := NewMockUserer(ctrl)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -180,7 +180,7 @@ func TestGetUser(t *testing.T) {
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{UserID: uuid.NewString(),
 				OrgID: uuid.NewString(), Role: common.Role_VIEWER}),
-			2*time.Second)
+			testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -203,7 +203,7 @@ func TestGetUser(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: uuid.NewString(),
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -231,7 +231,7 @@ func TestUpdateUser(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: user.OrgId,
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -266,7 +266,7 @@ func TestUpdateUser(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: user.OrgId,
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -290,7 +290,7 @@ func TestUpdateUser(t *testing.T) {
 		defer ctrl.Finish()
 		userer := NewMockUserer(ctrl)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -310,7 +310,7 @@ func TestUpdateUser(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: uuid.NewString(),
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -332,7 +332,7 @@ func TestUpdateUser(t *testing.T) {
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{UserID: uuid.NewString(),
 				OrgID: uuid.NewString(), Role: common.Role_VIEWER}),
-			2*time.Second)
+			testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -354,7 +354,7 @@ func TestUpdateUser(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: uuid.NewString(),
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -382,7 +382,7 @@ func TestUpdateUser(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: orgID,
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -406,7 +406,7 @@ func TestUpdateUser(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: user.OrgId,
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -435,7 +435,7 @@ func TestUpdateUser(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: user.OrgId,
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -463,7 +463,7 @@ func TestUpdateUserPassword(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: uuid.NewString(),
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -481,7 +481,7 @@ func TestUpdateUserPassword(t *testing.T) {
 		defer ctrl.Finish()
 		userer := NewMockUserer(ctrl)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -502,7 +502,7 @@ func TestUpdateUserPassword(t *testing.T) {
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{UserID: uuid.NewString(),
 				OrgID: uuid.NewString(), Role: common.Role_VIEWER}),
-			2*time.Second)
+			testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -522,7 +522,7 @@ func TestUpdateUserPassword(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: uuid.NewString(),
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -546,7 +546,7 @@ func TestUpdateUserPassword(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: uuid.NewString(),
-				Role: common.Role_ADMIN}), 6*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -573,7 +573,7 @@ func TestDeleteUser(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: uuid.NewString(),
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -590,7 +590,7 @@ func TestDeleteUser(t *testing.T) {
 		defer ctrl.Finish()
 		userer := NewMockUserer(ctrl)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -609,7 +609,7 @@ func TestDeleteUser(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: uuid.NewString(),
-				Role: common.Role_BUILDER}), 2*time.Second)
+				Role: common.Role_BUILDER}), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -631,7 +631,7 @@ func TestDeleteUser(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: uuid.NewString(),
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -665,7 +665,7 @@ func TestListUsers(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: orgID,
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -707,7 +707,7 @@ func TestListUsers(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: orgID,
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -734,7 +734,7 @@ func TestListUsers(t *testing.T) {
 		defer ctrl.Finish()
 		userer := NewMockUserer(ctrl)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -758,7 +758,7 @@ func TestListUsers(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{UserID: user.Id,
-				OrgID: user.OrgId, Role: common.Role_VIEWER}), 2*time.Second)
+				OrgID: user.OrgId, Role: common.Role_VIEWER}), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -789,7 +789,7 @@ func TestListUsers(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{UserID: user.Id,
-				OrgID: user.OrgId, Role: common.Role_VIEWER}), 2*time.Second)
+				OrgID: user.OrgId, Role: common.Role_VIEWER}), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -808,7 +808,7 @@ func TestListUsers(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: uuid.NewString(),
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -832,7 +832,7 @@ func TestListUsers(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: "aaa",
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)
@@ -864,7 +864,7 @@ func TestListUsers(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(session.NewContext(
 			context.Background(), &session.Session{OrgID: orgID,
-				Role: common.Role_ADMIN}), 2*time.Second)
+				Role: common.Role_ADMIN}), testTimeout)
 		defer cancel()
 
 		userSvc := NewUser(userer)

--- a/internal/api/test/datapoint_test.go
+++ b/internal/api/test/datapoint_test.go
@@ -26,7 +26,7 @@ func TestPublishDataPoints(t *testing.T) {
 			Attr: "motion", ValOneof: &common.DataPoint_IntVal{IntVal: 123},
 			Ts: timestamppb.New(time.Now().Add(-15 * time.Minute))}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		dpCli := api.NewDataPointServiceClient(globalAdminGRPCConn)
@@ -53,9 +53,10 @@ func TestPublishDataPoints(t *testing.T) {
 			if !proto.Equal(&message.ValidatorIn{Point: point,
 				OrgId: globalAdminOrgID, SkipToken: true}, vIn) {
 				t.Fatalf("\nExpect: %+v\nActual: %+v", &message.ValidatorIn{
-					Point: point, OrgId: globalAdminOrgID, SkipToken: true}, vIn)
+					Point: point, OrgId: globalAdminOrgID, SkipToken: true},
+					vIn)
 			}
-		case <-time.After(5 * time.Second):
+		case <-time.After(testTimeout):
 			t.Fatal("Message timed out")
 		}
 	})
@@ -64,7 +65,7 @@ func TestPublishDataPoints(t *testing.T) {
 		point := &common.DataPoint{UniqId: "api-point-" + random.String(16),
 			Attr: "motion", ValOneof: &common.DataPoint_IntVal{IntVal: 123}}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		dpCli := api.NewDataPointServiceClient(globalAdminGRPCConn)
@@ -97,7 +98,7 @@ func TestPublishDataPoints(t *testing.T) {
 				t.Fatalf("\nExpect: %+v\nActual: %+v", &message.ValidatorIn{
 					Point: point, OrgId: globalAdminOrgID, SkipToken: true}, vIn)
 			}
-		case <-time.After(5 * time.Second):
+		case <-time.After(testTimeout):
 			t.Fatal("Message timed out")
 		}
 	})
@@ -107,7 +108,7 @@ func TestPublishDataPoints(t *testing.T) {
 			Attr: "motion", ValOneof: &common.DataPoint_IntVal{IntVal: 123},
 			Ts: timestamppb.New(time.Now().Add(-15 * time.Minute))}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		dpCli := api.NewDataPointServiceClient(globalAdminGRPCConn)
@@ -125,7 +126,7 @@ func TestPublishDataPoints(t *testing.T) {
 			Attr: "motion", ValOneof: &common.DataPoint_IntVal{IntVal: 123},
 			Ts: timestamppb.New(time.Now().Add(-15 * time.Minute))}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		dpCli := api.NewDataPointServiceClient(secondaryViewerGRPCConn)
@@ -143,7 +144,7 @@ func TestListDataPoints(t *testing.T) {
 	t.Run("List data points by UniqID, dev ID, and attr", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		devCli := api.NewDeviceServiceClient(globalAdminGRPCConn)
@@ -177,7 +178,7 @@ func TestListDataPoints(t *testing.T) {
 
 		for _, point := range points {
 			ctx, cancel := context.WithTimeout(context.Background(),
-				2*time.Second)
+				testTimeout)
 			defer cancel()
 
 			// Set a new in-place timestamp.
@@ -194,7 +195,7 @@ func TestListDataPoints(t *testing.T) {
 			return points[i].Ts.AsTime().After(points[j].Ts.AsTime())
 		})
 
-		ctx, cancel = context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel = context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		// Verify results by UniqID.
@@ -265,7 +266,7 @@ func TestListDataPoints(t *testing.T) {
 			Attr: "motion", ValOneof: &common.DataPoint_IntVal{IntVal: 123},
 			Ts: timestamppb.Now(), TraceId: uuid.NewString()}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		err := globalDPDAO.Create(ctx, point, uuid.NewString())
@@ -285,7 +286,7 @@ func TestListDataPoints(t *testing.T) {
 	t.Run("List data points by invalid time range", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		dpCli := api.NewDataPointServiceClient(globalAdminGRPCConn)
@@ -304,7 +305,7 @@ func TestListDataPoints(t *testing.T) {
 	t.Run("List data points by invalid dev ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		dpCli := api.NewDataPointServiceClient(globalAdminGRPCConn)
@@ -325,7 +326,7 @@ func TestLatestDataPoints(t *testing.T) {
 	t.Run("Latest data points by valid UniqID and dev ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		devCli := api.NewDeviceServiceClient(globalAdminGRPCConn)
@@ -357,7 +358,7 @@ func TestLatestDataPoints(t *testing.T) {
 		for _, point := range points {
 			for i := 0; i < random.Intn(6)+3; i++ {
 				ctx, cancel := context.WithTimeout(context.Background(),
-					2*time.Second)
+					testTimeout)
 				defer cancel()
 
 				// Set a new in-place timestamp each pass.
@@ -375,7 +376,7 @@ func TestLatestDataPoints(t *testing.T) {
 			return points[i].Attr < points[j].Attr
 		})
 
-		ctx, cancel = context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel = context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		// Verify results by UniqID.
@@ -420,7 +421,7 @@ func TestLatestDataPoints(t *testing.T) {
 			Attr: "motion", ValOneof: &common.DataPoint_IntVal{IntVal: 123},
 			Ts: timestamppb.Now(), TraceId: uuid.NewString()}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		err := globalDPDAO.Create(ctx, point, uuid.NewString())
@@ -440,7 +441,7 @@ func TestLatestDataPoints(t *testing.T) {
 	t.Run("Latest data points by invalid dev ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		dpCli := api.NewDataPointServiceClient(globalAdminGRPCConn)

--- a/internal/api/test/device_test.go
+++ b/internal/api/test/device_test.go
@@ -24,7 +24,7 @@ func TestCreateDevice(t *testing.T) {
 
 		dev := random.Device("api-device", uuid.NewString())
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		devCli := api.NewDeviceServiceClient(globalAdminGRPCConn)
@@ -48,7 +48,7 @@ func TestCreateDevice(t *testing.T) {
 		dev := random.Device("api-device", uuid.NewString())
 		dev.UniqId = strings.ToUpper(dev.UniqId)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		devCli := api.NewDeviceServiceClient(globalAdminGRPCConn)
@@ -72,7 +72,7 @@ func TestCreateDevice(t *testing.T) {
 		dev := random.Device("api-device", uuid.NewString())
 		dev.UniqId = "api-device-" + random.String(40)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		devCli := api.NewDeviceServiceClient(globalAdminGRPCConn)
@@ -89,7 +89,7 @@ func TestCreateDevice(t *testing.T) {
 	t.Run("Create valid device with insufficient role", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		devCli := api.NewDeviceServiceClient(secondaryViewerGRPCConn)
@@ -105,7 +105,7 @@ func TestCreateDevice(t *testing.T) {
 func TestGetDevice(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
 	devCli := api.NewDeviceServiceClient(globalAdminGRPCConn)
@@ -117,7 +117,7 @@ func TestGetDevice(t *testing.T) {
 	t.Run("Get device by valid ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		devCli := api.NewDeviceServiceClient(globalAdminGRPCConn)
@@ -136,7 +136,7 @@ func TestGetDevice(t *testing.T) {
 	t.Run("Get device by unknown ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		devCli := api.NewDeviceServiceClient(globalAdminGRPCConn)
@@ -151,7 +151,7 @@ func TestGetDevice(t *testing.T) {
 	t.Run("Get are isolated by org ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		secCli := api.NewDeviceServiceClient(secondaryAdminGRPCConn)
@@ -170,7 +170,7 @@ func TestUpdateDevice(t *testing.T) {
 	t.Run("Update device by valid device", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		devCli := api.NewDeviceServiceClient(globalAdminGRPCConn)
@@ -200,7 +200,7 @@ func TestUpdateDevice(t *testing.T) {
 	t.Run("Partial update device by valid device", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		devCli := api.NewDeviceServiceClient(globalAdminGRPCConn)
@@ -231,7 +231,7 @@ func TestUpdateDevice(t *testing.T) {
 	t.Run("Update device with insufficient role", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		devCli := api.NewDeviceServiceClient(secondaryViewerGRPCConn)
@@ -246,7 +246,7 @@ func TestUpdateDevice(t *testing.T) {
 	t.Run("Update nil device", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		devCli := api.NewDeviceServiceClient(globalAdminGRPCConn)
@@ -261,7 +261,7 @@ func TestUpdateDevice(t *testing.T) {
 	t.Run("Partial update invalid field mask", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		devCli := api.NewDeviceServiceClient(globalAdminGRPCConn)
@@ -277,7 +277,7 @@ func TestUpdateDevice(t *testing.T) {
 	t.Run("Partial update device by unknown device", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		devCli := api.NewDeviceServiceClient(globalAdminGRPCConn)
@@ -294,7 +294,7 @@ func TestUpdateDevice(t *testing.T) {
 	t.Run("Update device by unknown device", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		devCli := api.NewDeviceServiceClient(globalAdminGRPCConn)
@@ -309,7 +309,7 @@ func TestUpdateDevice(t *testing.T) {
 	t.Run("Updates are isolated by org ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		devCli := api.NewDeviceServiceClient(globalAdminGRPCConn)
@@ -334,7 +334,7 @@ func TestUpdateDevice(t *testing.T) {
 	t.Run("Update device validation failure", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		devCli := api.NewDeviceServiceClient(globalAdminGRPCConn)
@@ -359,7 +359,7 @@ func TestUpdateDevice(t *testing.T) {
 	t.Run("Update device by invalid device", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		devCli := api.NewDeviceServiceClient(globalAdminGRPCConn)
@@ -386,7 +386,7 @@ func TestDeleteDevice(t *testing.T) {
 	t.Run("Delete device by valid ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		devCli := api.NewDeviceServiceClient(globalAdminGRPCConn)
@@ -404,7 +404,7 @@ func TestDeleteDevice(t *testing.T) {
 			t.Parallel()
 
 			ctx, cancel := context.WithTimeout(context.Background(),
-				2*time.Second)
+				testTimeout)
 			defer cancel()
 
 			devCli := api.NewDeviceServiceClient(globalAdminGRPCConn)
@@ -420,7 +420,7 @@ func TestDeleteDevice(t *testing.T) {
 	t.Run("Delete device with insufficient role", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		devCli := api.NewDeviceServiceClient(secondaryViewerGRPCConn)
@@ -434,7 +434,7 @@ func TestDeleteDevice(t *testing.T) {
 	t.Run("Delete device by unknown ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		devCli := api.NewDeviceServiceClient(globalAdminGRPCConn)
@@ -448,7 +448,7 @@ func TestDeleteDevice(t *testing.T) {
 	t.Run("Deletes are isolated by org ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		devCli := api.NewDeviceServiceClient(globalAdminGRPCConn)
@@ -469,7 +469,7 @@ func TestDeleteDevice(t *testing.T) {
 func TestListDevices(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
 	devIDs := []string{}
@@ -488,7 +488,7 @@ func TestListDevices(t *testing.T) {
 	t.Run("List devices by valid org ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		devCli := api.NewDeviceServiceClient(globalAdminGRPCConn)
@@ -511,7 +511,7 @@ func TestListDevices(t *testing.T) {
 	t.Run("List devices by valid org ID with next page", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		devCli := api.NewDeviceServiceClient(globalAdminGRPCConn)
@@ -536,7 +536,7 @@ func TestListDevices(t *testing.T) {
 	t.Run("Lists are isolated by org ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		secCli := api.NewDeviceServiceClient(secondaryAdminGRPCConn)
@@ -550,7 +550,7 @@ func TestListDevices(t *testing.T) {
 	t.Run("List devices by invalid page token", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		devCli := api.NewDeviceServiceClient(globalAdminGRPCConn)

--- a/internal/api/test/main_test.go
+++ b/internal/api/test/main_test.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/thingspect/api/go/common"
 	"github.com/thingspect/atlas/internal/api/api"
@@ -22,6 +23,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/encoding/gzip"
 )
+
+const testTimeout = 8 * time.Second
 
 var (
 	globalOrgDAO  *org.DAO

--- a/internal/api/test/session_test.go
+++ b/internal/api/test/session_test.go
@@ -17,7 +17,7 @@ import (
 func TestLogin(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
 	createOrg, err := globalOrgDAO.Create(ctx, random.Org("api-session"))
@@ -62,7 +62,7 @@ func TestLogin(t *testing.T) {
 	t.Run("Log in valid user", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		sessCli := api.NewSessionServiceClient(globalNoAuthGRPCConn)
@@ -80,7 +80,7 @@ func TestLogin(t *testing.T) {
 	t.Run("Log in unknown user", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		sessCli := api.NewSessionServiceClient(globalNoAuthGRPCConn)
@@ -96,7 +96,7 @@ func TestLogin(t *testing.T) {
 	t.Run("Log in wrong password", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		sessCli := api.NewSessionServiceClient(globalNoAuthGRPCConn)
@@ -112,7 +112,7 @@ func TestLogin(t *testing.T) {
 	t.Run("Log in disabled user", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		sessCli := api.NewSessionServiceClient(globalNoAuthGRPCConn)
@@ -128,7 +128,7 @@ func TestLogin(t *testing.T) {
 	t.Run("Log in contact user", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		sessCli := api.NewSessionServiceClient(globalNoAuthGRPCConn)

--- a/internal/api/test/user_test.go
+++ b/internal/api/test/user_test.go
@@ -25,7 +25,7 @@ func TestCreateUser(t *testing.T) {
 
 		user := random.User("api-user", uuid.NewString())
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userCli := api.NewUserServiceClient(globalAdminGRPCConn)
@@ -50,7 +50,7 @@ func TestCreateUser(t *testing.T) {
 		user := random.User("api-user", uuid.NewString())
 		user.Email = "api-user-" + random.String(80)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userCli := api.NewUserServiceClient(globalAdminGRPCConn)
@@ -67,7 +67,7 @@ func TestCreateUser(t *testing.T) {
 	t.Run("Create valid user with insufficient role", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userCli := api.NewUserServiceClient(secondaryViewerGRPCConn)
@@ -83,7 +83,7 @@ func TestCreateUser(t *testing.T) {
 func TestGetUser(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
 	userCli := api.NewUserServiceClient(globalAdminGRPCConn)
@@ -95,7 +95,7 @@ func TestGetUser(t *testing.T) {
 	t.Run("Get user by valid ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userCli := api.NewUserServiceClient(globalAdminGRPCConn)
@@ -114,7 +114,7 @@ func TestGetUser(t *testing.T) {
 	t.Run("Get user with insufficient role", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userCli := api.NewUserServiceClient(secondaryViewerGRPCConn)
@@ -129,7 +129,7 @@ func TestGetUser(t *testing.T) {
 	t.Run("Get user by unknown ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userCli := api.NewUserServiceClient(globalAdminGRPCConn)
@@ -144,7 +144,7 @@ func TestGetUser(t *testing.T) {
 	t.Run("Get are isolated by org ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		secCli := api.NewUserServiceClient(secondaryAdminGRPCConn)
@@ -163,7 +163,7 @@ func TestUpdateUser(t *testing.T) {
 	t.Run("Update user by valid user", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userCli := api.NewUserServiceClient(globalAdminGRPCConn)
@@ -195,7 +195,7 @@ func TestUpdateUser(t *testing.T) {
 	t.Run("Partial update user by valid user", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userCli := api.NewUserServiceClient(globalAdminGRPCConn)
@@ -226,7 +226,7 @@ func TestUpdateUser(t *testing.T) {
 	t.Run("Update nil user", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userCli := api.NewUserServiceClient(globalAdminGRPCConn)
@@ -241,7 +241,7 @@ func TestUpdateUser(t *testing.T) {
 	t.Run("Update user with insufficient role", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userCli := api.NewUserServiceClient(secondaryViewerGRPCConn)
@@ -256,7 +256,7 @@ func TestUpdateUser(t *testing.T) {
 	t.Run("Partial update invalid field mask", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userCli := api.NewUserServiceClient(globalAdminGRPCConn)
@@ -272,7 +272,7 @@ func TestUpdateUser(t *testing.T) {
 	t.Run("Partial update user by unknown user", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userCli := api.NewUserServiceClient(globalAdminGRPCConn)
@@ -288,7 +288,7 @@ func TestUpdateUser(t *testing.T) {
 	t.Run("Update user by unknown user", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userCli := api.NewUserServiceClient(globalAdminGRPCConn)
@@ -303,7 +303,7 @@ func TestUpdateUser(t *testing.T) {
 	t.Run("Updates are isolated by org ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userCli := api.NewUserServiceClient(globalAdminGRPCConn)
@@ -328,7 +328,7 @@ func TestUpdateUser(t *testing.T) {
 	t.Run("Update user validation failure", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userCli := api.NewUserServiceClient(globalAdminGRPCConn)
@@ -353,7 +353,7 @@ func TestUpdateUser(t *testing.T) {
 	t.Run("Update user by invalid user", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userCli := api.NewUserServiceClient(globalAdminGRPCConn)
@@ -381,7 +381,7 @@ func TestUpdateUserPassword(t *testing.T) {
 	t.Run("Update user password by valid ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userCli := api.NewUserServiceClient(globalAdminGRPCConn)
@@ -399,7 +399,7 @@ func TestUpdateUserPassword(t *testing.T) {
 	t.Run("Update user password with insufficient role", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userCli := api.NewUserServiceClient(secondaryViewerGRPCConn)
@@ -414,7 +414,7 @@ func TestUpdateUserPassword(t *testing.T) {
 	t.Run("Update user password with weak password", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userCli := api.NewUserServiceClient(globalAdminGRPCConn)
@@ -433,7 +433,7 @@ func TestUpdateUserPassword(t *testing.T) {
 	t.Run("Update user password by unknown ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userCli := api.NewUserServiceClient(globalAdminGRPCConn)
@@ -448,7 +448,7 @@ func TestUpdateUserPassword(t *testing.T) {
 	t.Run("Password updates are isolated by org ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userCli := api.NewUserServiceClient(globalAdminGRPCConn)
@@ -472,7 +472,7 @@ func TestDeleteUser(t *testing.T) {
 	t.Run("Delete user by valid ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userCli := api.NewUserServiceClient(globalAdminGRPCConn)
@@ -490,7 +490,7 @@ func TestDeleteUser(t *testing.T) {
 			t.Parallel()
 
 			ctx, cancel := context.WithTimeout(context.Background(),
-				2*time.Second)
+				testTimeout)
 			defer cancel()
 
 			userCli := api.NewUserServiceClient(globalAdminGRPCConn)
@@ -506,7 +506,7 @@ func TestDeleteUser(t *testing.T) {
 	t.Run("Delete user with insufficient role", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userCli := api.NewUserServiceClient(secondaryViewerGRPCConn)
@@ -520,7 +520,7 @@ func TestDeleteUser(t *testing.T) {
 	t.Run("Delete user by unknown ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userCli := api.NewUserServiceClient(globalAdminGRPCConn)
@@ -534,7 +534,7 @@ func TestDeleteUser(t *testing.T) {
 	t.Run("Deletes are isolated by org ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userCli := api.NewUserServiceClient(globalAdminGRPCConn)
@@ -555,7 +555,7 @@ func TestDeleteUser(t *testing.T) {
 func TestListUsers(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
 	userIDs := []string{}
@@ -576,7 +576,7 @@ func TestListUsers(t *testing.T) {
 	t.Run("List users by valid org ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userCli := api.NewUserServiceClient(globalAdminGRPCConn)
@@ -600,7 +600,7 @@ func TestListUsers(t *testing.T) {
 	t.Run("List users by valid org ID with next page", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userCli := api.NewUserServiceClient(globalAdminGRPCConn)
@@ -625,7 +625,7 @@ func TestListUsers(t *testing.T) {
 	t.Run("List users with insufficient role", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		secCli := api.NewUserServiceClient(secondaryViewerGRPCConn)
@@ -639,7 +639,7 @@ func TestListUsers(t *testing.T) {
 	t.Run("Lists are isolated by org ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		secCli := api.NewUserServiceClient(secondaryAdminGRPCConn)
@@ -653,7 +653,7 @@ func TestListUsers(t *testing.T) {
 	t.Run("List users by invalid page token", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		userCli := api.NewUserServiceClient(globalAdminGRPCConn)

--- a/internal/validator/test/main_test.go
+++ b/internal/validator/test/main_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/thingspect/atlas/internal/validator/config"
 	"github.com/thingspect/atlas/internal/validator/validator"
@@ -16,6 +17,8 @@ import (
 	testconfig "github.com/thingspect/atlas/pkg/test/config"
 	"github.com/thingspect/atlas/pkg/test/random"
 )
+
+const testTimeout = 6 * time.Second
 
 var (
 	globalVInSubTopic string

--- a/internal/validator/test/validator_test.go
+++ b/internal/validator/test/validator_test.go
@@ -24,7 +24,7 @@ func TestValidateMessages(t *testing.T) {
 	boolVal := &common.DataPoint_BoolVal{BoolVal: []bool{true,
 		false}[random.Intn(2)]}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
 	createOrg, err := globalOrgDAO.Create(ctx, random.Org("val"))
@@ -103,7 +103,7 @@ func TestValidateMessages(t *testing.T) {
 				if !proto.Equal(lTest.res, vOut) {
 					t.Fatalf("\nExpect: %+v\nActual: %+v", lTest.res, vOut)
 				}
-			case <-time.After(5 * time.Second):
+			case <-time.After(testTimeout):
 				t.Fatal("Message timed out")
 			}
 		})
@@ -114,7 +114,7 @@ func TestValidateMessagesError(t *testing.T) {
 	uniqID := "val-" + random.String(16)
 	disUniqID := "val-" + random.String(16)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
 	createOrg, err := globalOrgDAO.Create(ctx, random.Org("val"))

--- a/pkg/alog/ctx_logger_test.go
+++ b/pkg/alog/ctx_logger_test.go
@@ -11,13 +11,15 @@ import (
 	"github.com/thingspect/atlas/pkg/test/random"
 )
 
+const testTimeout = 2 * time.Second
+
 func TestNewFromContext(t *testing.T) {
 	t.Parallel()
 
 	logger := &CtxLogger{Logger: WithStr(random.String(10), random.String(10))}
 	t.Logf("logger: %+v", logger)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
 	ctx = NewContext(ctx, logger)
@@ -29,7 +31,7 @@ func TestNewFromContext(t *testing.T) {
 func TestFromContextDefault(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
 	ctxLogger := FromContext(ctx)

--- a/pkg/dao/datapoint/crudl_test.go
+++ b/pkg/dao/datapoint/crudl_test.go
@@ -58,7 +58,7 @@ func TestCreate(t *testing.T) {
 				t.Parallel()
 
 				ctx, cancel := context.WithTimeout(context.Background(),
-					2*time.Second)
+					testTimeout)
 				defer cancel()
 
 				err := globalDPDAO.Create(ctx, lTest.inpPoint, lTest.inpOrgID)
@@ -95,7 +95,7 @@ func TestCreate(t *testing.T) {
 				t.Parallel()
 
 				ctx, cancel := context.WithTimeout(context.Background(),
-					2*time.Second)
+					testTimeout)
 				defer cancel()
 
 				err := globalDPDAO.Create(ctx, lTest.inpPoint, orgID)
@@ -113,7 +113,7 @@ func TestCreate(t *testing.T) {
 			Ts: timestamppb.Now(), TraceId: uuid.NewString()}
 		orgID := uuid.NewString()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		err := globalDPDAO.Create(ctx, point, orgID)
@@ -132,7 +132,7 @@ func TestList(t *testing.T) {
 	t.Run("List data points by UniqID, dev ID, and attr", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		createOrg, err := globalOrgDAO.Create(ctx, random.Org("dao-device"))
@@ -167,7 +167,7 @@ func TestList(t *testing.T) {
 
 		for _, point := range points {
 			ctx, cancel := context.WithTimeout(context.Background(),
-				2*time.Second)
+				testTimeout)
 			defer cancel()
 
 			// Set a new in-place timestamp.
@@ -184,7 +184,7 @@ func TestList(t *testing.T) {
 			return points[i].Ts.AsTime().After(points[j].Ts.AsTime())
 		})
 
-		ctx, cancel = context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel = context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		// Verify results by UniqID.
@@ -251,7 +251,7 @@ func TestList(t *testing.T) {
 			Ts: timestamppb.Now(), TraceId: uuid.NewString()}
 		orgID := uuid.NewString()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		err := globalDPDAO.Create(ctx, point, orgID)
@@ -268,7 +268,7 @@ func TestList(t *testing.T) {
 	t.Run("List data points by invalid org ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		listPoints, err := globalDPDAO.List(ctx, random.String(10),
@@ -285,7 +285,7 @@ func TestLatest(t *testing.T) {
 	t.Run("Latest data points by valid UniqID and dev ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		createOrg, err := globalOrgDAO.Create(ctx, random.Org("dao-device"))
@@ -318,7 +318,7 @@ func TestLatest(t *testing.T) {
 		for _, point := range points {
 			for i := 0; i < random.Intn(6)+3; i++ {
 				ctx, cancel := context.WithTimeout(context.Background(),
-					2*time.Second)
+					testTimeout)
 				defer cancel()
 
 				// Set a new in-place timestamp each pass.
@@ -336,7 +336,7 @@ func TestLatest(t *testing.T) {
 			return points[i].Attr < points[j].Attr
 		})
 
-		ctx, cancel = context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel = context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		// Verify results by UniqID.
@@ -378,7 +378,7 @@ func TestLatest(t *testing.T) {
 			Attr: "motion", ValOneof: &common.DataPoint_IntVal{IntVal: 123},
 			Ts: timestamppb.Now(), TraceId: uuid.NewString()}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		err := globalDPDAO.Create(ctx, point, uuid.NewString())
@@ -395,7 +395,7 @@ func TestLatest(t *testing.T) {
 	t.Run("Latest data points by invalid dev ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		latPoints, err := globalDPDAO.Latest(ctx, uuid.NewString(), "",

--- a/pkg/dao/datapoint/main_test.go
+++ b/pkg/dao/datapoint/main_test.go
@@ -6,12 +6,15 @@ import (
 	"log"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/thingspect/atlas/pkg/dao/device"
 	"github.com/thingspect/atlas/pkg/dao/org"
 	"github.com/thingspect/atlas/pkg/postgres"
 	"github.com/thingspect/atlas/pkg/test/config"
 )
+
+const testTimeout = 4 * time.Second
 
 var (
 	globalDPDAO  *DAO

--- a/pkg/dao/device/crudl_test.go
+++ b/pkg/dao/device/crudl_test.go
@@ -18,7 +18,7 @@ import (
 func TestCreate(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
 	createOrg, err := globalOrgDAO.Create(ctx, random.Org("dao-device"))
@@ -28,7 +28,7 @@ func TestCreate(t *testing.T) {
 	t.Run("Create valid device", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		dev := random.Device("dao-device", createOrg.Id)
@@ -47,7 +47,7 @@ func TestCreate(t *testing.T) {
 	t.Run("Create valid device with uppercase UniqId", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		dev := random.Device("dao-device", createOrg.Id)
@@ -67,7 +67,7 @@ func TestCreate(t *testing.T) {
 	t.Run("Create invalid device", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		dev := random.Device("dao-device", createOrg.Id)
@@ -82,7 +82,7 @@ func TestCreate(t *testing.T) {
 func TestRead(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
 	createOrg, err := globalOrgDAO.Create(ctx, random.Org("dao-device"))
@@ -97,7 +97,7 @@ func TestRead(t *testing.T) {
 	t.Run("Read device by valid ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		readDev, err := globalDevDAO.Read(ctx, createDev.Id, createDev.OrgId)
@@ -109,7 +109,7 @@ func TestRead(t *testing.T) {
 	t.Run("Read device by unknown ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		readDev, err := globalDevDAO.Read(ctx, uuid.NewString(),
@@ -122,7 +122,7 @@ func TestRead(t *testing.T) {
 	t.Run("Reads are isolated by org ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		readDev, err := globalDevDAO.Read(ctx, createDev.Id,
@@ -135,7 +135,7 @@ func TestRead(t *testing.T) {
 	t.Run("Read device by invalid ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		readDev, err := globalDevDAO.Read(ctx, random.String(10),
@@ -149,7 +149,7 @@ func TestRead(t *testing.T) {
 func TestReadByUniqID(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
 	createOrg, err := globalOrgDAO.Create(ctx, random.Org("dao-device"))
@@ -164,7 +164,7 @@ func TestReadByUniqID(t *testing.T) {
 	t.Run("Read device by valid UniqID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		readDev, err := globalDevDAO.ReadByUniqID(ctx, createDev.UniqId)
@@ -176,7 +176,7 @@ func TestReadByUniqID(t *testing.T) {
 	t.Run("Read device by unknown UniqID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		readDev, err := globalDevDAO.ReadByUniqID(ctx, uuid.NewString())
@@ -189,7 +189,7 @@ func TestReadByUniqID(t *testing.T) {
 func TestUpdate(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
 	createOrg, err := globalOrgDAO.Create(ctx, random.Org("dao-device"))
@@ -199,7 +199,7 @@ func TestUpdate(t *testing.T) {
 	t.Run("Update device by valid device", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		createDev, err := globalDevDAO.Create(ctx, random.Device("dao-device",
@@ -226,7 +226,7 @@ func TestUpdate(t *testing.T) {
 	t.Run("Update unknown device", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		updateDev, err := globalDevDAO.Update(ctx, random.Device("dao-device",
@@ -239,7 +239,7 @@ func TestUpdate(t *testing.T) {
 	t.Run("Updates are isolated by org ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		createDev, err := globalDevDAO.Create(ctx, random.Device("dao-device",
@@ -260,7 +260,7 @@ func TestUpdate(t *testing.T) {
 	t.Run("Update device by invalid device", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		createDev, err := globalDevDAO.Create(ctx, random.Device("dao-device",
@@ -281,7 +281,7 @@ func TestUpdate(t *testing.T) {
 func TestDelete(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
 	createOrg, err := globalOrgDAO.Create(ctx, random.Org("dao-device"))
@@ -291,7 +291,7 @@ func TestDelete(t *testing.T) {
 	t.Run("Delete device by valid ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		createDev, err := globalDevDAO.Create(ctx, random.Device("dao-device",
@@ -307,7 +307,7 @@ func TestDelete(t *testing.T) {
 			t.Parallel()
 
 			ctx, cancel := context.WithTimeout(context.Background(),
-				2*time.Second)
+				testTimeout)
 			defer cancel()
 
 			readDev, err := globalDevDAO.Read(ctx, createDev.Id,
@@ -321,7 +321,7 @@ func TestDelete(t *testing.T) {
 	t.Run("Delete device by unknown ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		err := globalDevDAO.Delete(ctx, uuid.NewString(), createOrg.Id)
@@ -332,7 +332,7 @@ func TestDelete(t *testing.T) {
 	t.Run("Deletes are isolated by org ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		createDev, err := globalDevDAO.Create(ctx, random.Device("dao-device",
@@ -349,7 +349,7 @@ func TestDelete(t *testing.T) {
 func TestList(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
 	createOrg, err := globalOrgDAO.Create(ctx, random.Org("dao-device"))
@@ -373,7 +373,7 @@ func TestList(t *testing.T) {
 	t.Run("List devices by valid org ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		listDevs, listCount, err := globalDevDAO.List(ctx, createOrg.Id,
@@ -396,7 +396,7 @@ func TestList(t *testing.T) {
 	t.Run("List devices by valid org ID with pagination", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		listDevs, listCount, err := globalDevDAO.List(ctx, createOrg.Id,
@@ -419,7 +419,7 @@ func TestList(t *testing.T) {
 	t.Run("List devices by valid org ID with limit", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		listDevs, listCount, err := globalDevDAO.List(ctx, createOrg.Id,
@@ -433,7 +433,7 @@ func TestList(t *testing.T) {
 	t.Run("Lists are isolated by org ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		listDevs, listCount, err := globalDevDAO.List(ctx, uuid.NewString(),
@@ -447,7 +447,7 @@ func TestList(t *testing.T) {
 	t.Run("List devices by invalid org ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		listDevs, listCount, err := globalDevDAO.List(ctx, random.String(10),

--- a/pkg/dao/device/main_test.go
+++ b/pkg/dao/device/main_test.go
@@ -6,11 +6,14 @@ import (
 	"log"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/thingspect/atlas/pkg/dao/org"
 	"github.com/thingspect/atlas/pkg/postgres"
 	"github.com/thingspect/atlas/pkg/test/config"
 )
+
+const testTimeout = 8 * time.Second
 
 var (
 	globalOrgDAO *org.DAO

--- a/pkg/dao/org/crudl_test.go
+++ b/pkg/dao/org/crudl_test.go
@@ -20,7 +20,7 @@ func TestCreate(t *testing.T) {
 	t.Run("Create valid org", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		org := random.Org("dao-org")
@@ -37,7 +37,7 @@ func TestCreate(t *testing.T) {
 	t.Run("Create valid org with uppercase name", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		org := random.Org("dao-org")
@@ -55,7 +55,7 @@ func TestCreate(t *testing.T) {
 	t.Run("Create invalid org", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		org := random.Org("dao-org")
@@ -70,7 +70,7 @@ func TestCreate(t *testing.T) {
 func TestRead(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
 	createOrg, err := globalOrgDAO.Create(ctx, random.Org("dao-org"))
@@ -80,7 +80,7 @@ func TestRead(t *testing.T) {
 	t.Run("Read org by valid ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		readOrg, err := globalOrgDAO.Read(ctx, createOrg.Id)
@@ -92,7 +92,7 @@ func TestRead(t *testing.T) {
 	t.Run("Read org by unknown ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		readOrg, err := globalOrgDAO.Read(ctx, uuid.NewString())
@@ -104,7 +104,7 @@ func TestRead(t *testing.T) {
 	t.Run("Read org by invalid ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		readOrg, err := globalOrgDAO.Read(ctx, random.String(10))
@@ -120,7 +120,7 @@ func TestUpdate(t *testing.T) {
 	t.Run("Update org by valid org", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		createOrg, err := globalOrgDAO.Create(ctx, random.Org("dao-org"))
@@ -144,7 +144,7 @@ func TestUpdate(t *testing.T) {
 	t.Run("Update unknown org", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		updateOrg, err := globalOrgDAO.Update(ctx, random.Org("dao-org"))
@@ -156,7 +156,7 @@ func TestUpdate(t *testing.T) {
 	t.Run("Update org by invalid org", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		createOrg, err := globalOrgDAO.Create(ctx, random.Org("dao-org"))
@@ -179,7 +179,7 @@ func TestDelete(t *testing.T) {
 	t.Run("Delete org by valid ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		createOrg, err := globalOrgDAO.Create(ctx, random.Org("dao-org"))
@@ -194,7 +194,7 @@ func TestDelete(t *testing.T) {
 			t.Parallel()
 
 			ctx, cancel := context.WithTimeout(context.Background(),
-				2*time.Second)
+				testTimeout)
 			defer cancel()
 
 			readOrg, err := globalOrgDAO.Read(ctx, createOrg.Id)
@@ -207,7 +207,7 @@ func TestDelete(t *testing.T) {
 	t.Run("Delete org by unknown ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		err := globalOrgDAO.Delete(ctx, uuid.NewString())
@@ -219,7 +219,7 @@ func TestDelete(t *testing.T) {
 func TestList(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
 	var lastOrgID string
@@ -234,7 +234,7 @@ func TestList(t *testing.T) {
 	t.Run("List orgs", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		listOrgs, err := globalOrgDAO.List(ctx)

--- a/pkg/dao/org/main_test.go
+++ b/pkg/dao/org/main_test.go
@@ -6,10 +6,13 @@ import (
 	"log"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/thingspect/atlas/pkg/postgres"
 	"github.com/thingspect/atlas/pkg/test/config"
 )
+
+const testTimeout = 8 * time.Second
 
 var globalOrgDAO *DAO
 

--- a/pkg/dao/user/crudl_test.go
+++ b/pkg/dao/user/crudl_test.go
@@ -19,7 +19,7 @@ import (
 func TestCreate(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
 	createOrg, err := globalOrgDAO.Create(ctx, random.Org("dao-user"))
@@ -29,7 +29,7 @@ func TestCreate(t *testing.T) {
 	t.Run("Create valid user", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		user := random.User("dao-user", createOrg.Id)
@@ -49,7 +49,7 @@ func TestCreate(t *testing.T) {
 	t.Run("Create invalid user", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		user := random.User("dao-user", createOrg.Id)
@@ -64,7 +64,7 @@ func TestCreate(t *testing.T) {
 func TestRead(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
 	createOrg, err := globalOrgDAO.Create(ctx, random.Org("dao-user"))
@@ -79,7 +79,7 @@ func TestRead(t *testing.T) {
 	t.Run("Read user by valid ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		readUser, err := globalUserDAO.Read(ctx, createUser.Id,
@@ -92,7 +92,7 @@ func TestRead(t *testing.T) {
 	t.Run("Read user by unknown ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		readUser, err := globalUserDAO.Read(ctx, uuid.NewString(),
@@ -105,7 +105,7 @@ func TestRead(t *testing.T) {
 	t.Run("Reads are isolated by org ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		readUser, err := globalUserDAO.Read(ctx, createUser.Id,
@@ -118,7 +118,7 @@ func TestRead(t *testing.T) {
 	t.Run("Read user by invalid ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		readUser, err := globalUserDAO.Read(ctx, random.String(10),
@@ -132,7 +132,7 @@ func TestRead(t *testing.T) {
 func TestReadByEmail(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
 	createOrg, err := globalOrgDAO.Create(ctx, random.Org("dao-user"))
@@ -152,7 +152,7 @@ func TestReadByEmail(t *testing.T) {
 	t.Run("Read user by valid email", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		readUser, readHash, err := globalUserDAO.ReadByEmail(ctx,
@@ -178,7 +178,7 @@ func TestReadByEmail(t *testing.T) {
 	t.Run("Read user by unknown email", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		readUser, readHash, err := globalUserDAO.ReadByEmail(ctx,
@@ -192,7 +192,7 @@ func TestReadByEmail(t *testing.T) {
 	t.Run("Reads are isolated by org name", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		readUser, readHash, err := globalUserDAO.ReadByEmail(ctx,
@@ -207,7 +207,7 @@ func TestReadByEmail(t *testing.T) {
 func TestUpdate(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
 	createOrg, err := globalOrgDAO.Create(ctx, random.Org("dao-user"))
@@ -217,7 +217,7 @@ func TestUpdate(t *testing.T) {
 	t.Run("Update user by valid user", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		createUser, err := globalUserDAO.Create(ctx, random.User("dao-user",
@@ -246,7 +246,7 @@ func TestUpdate(t *testing.T) {
 	t.Run("Update unknown user", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		updateUser, err := globalUserDAO.Update(ctx, random.User("dao-user",
@@ -259,7 +259,7 @@ func TestUpdate(t *testing.T) {
 	t.Run("Updates are isolated by org ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		createUser, err := globalUserDAO.Create(ctx, random.User("dao-user",
@@ -280,7 +280,7 @@ func TestUpdate(t *testing.T) {
 	t.Run("Update user by invalid user", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		createUser, err := globalUserDAO.Create(ctx, random.User("dao-user",
@@ -302,7 +302,7 @@ func TestUpdate(t *testing.T) {
 func TestUpdatePassword(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
 	createOrg, err := globalOrgDAO.Create(ctx, random.Org("dao-user"))
@@ -312,7 +312,7 @@ func TestUpdatePassword(t *testing.T) {
 	t.Run("Update user password by valid ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		createUser, err := globalUserDAO.Create(ctx, random.User("dao-user",
@@ -329,7 +329,7 @@ func TestUpdatePassword(t *testing.T) {
 	t.Run("Update user password by unknown ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		err := globalUserDAO.UpdatePassword(ctx, uuid.NewString(),
@@ -341,7 +341,7 @@ func TestUpdatePassword(t *testing.T) {
 	t.Run("Password updates are isolated by org ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		createUser, err := globalUserDAO.Create(ctx, random.User("dao-user",
@@ -359,7 +359,7 @@ func TestUpdatePassword(t *testing.T) {
 func TestDelete(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
 	createOrg, err := globalOrgDAO.Create(ctx, random.Org("dao-user"))
@@ -369,7 +369,7 @@ func TestDelete(t *testing.T) {
 	t.Run("Delete user by valid ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		createUser, err := globalUserDAO.Create(ctx, random.User("dao-user",
@@ -385,7 +385,7 @@ func TestDelete(t *testing.T) {
 			t.Parallel()
 
 			ctx, cancel := context.WithTimeout(context.Background(),
-				2*time.Second)
+				testTimeout)
 			defer cancel()
 
 			readUser, err := globalUserDAO.Read(ctx, createUser.Id,
@@ -399,7 +399,7 @@ func TestDelete(t *testing.T) {
 	t.Run("Delete user by unknown ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		err := globalUserDAO.Delete(ctx, uuid.NewString(), createOrg.Id)
@@ -410,7 +410,7 @@ func TestDelete(t *testing.T) {
 	t.Run("Deletes are isolated by org ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		createUser, err := globalUserDAO.Create(ctx, random.User("dao-user",
@@ -427,7 +427,7 @@ func TestDelete(t *testing.T) {
 func TestList(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
 	createOrg, err := globalOrgDAO.Create(ctx, random.Org("dao-user"))
@@ -453,7 +453,7 @@ func TestList(t *testing.T) {
 	t.Run("List users by valid org ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		listUsers, listCount, err := globalUserDAO.List(ctx, createOrg.Id,
@@ -477,7 +477,7 @@ func TestList(t *testing.T) {
 	t.Run("List users by valid org ID with pagination", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		listUsers, listCount, err := globalUserDAO.List(ctx, createOrg.Id,
@@ -501,7 +501,7 @@ func TestList(t *testing.T) {
 	t.Run("List users by valid org ID with limit", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		listUsers, listCount, err := globalUserDAO.List(ctx, createOrg.Id,
@@ -515,7 +515,7 @@ func TestList(t *testing.T) {
 	t.Run("Lists are isolated by org ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		listUsers, listCount, err := globalUserDAO.List(ctx,
@@ -529,7 +529,7 @@ func TestList(t *testing.T) {
 	t.Run("List users by invalid org ID", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
 		listUsers, listCount, err := globalUserDAO.List(ctx, random.String(10),

--- a/pkg/dao/user/main_test.go
+++ b/pkg/dao/user/main_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/thingspect/atlas/pkg/crypto"
 	"github.com/thingspect/atlas/pkg/dao/org"
@@ -13,6 +14,8 @@ import (
 	"github.com/thingspect/atlas/pkg/test/config"
 	"github.com/thingspect/atlas/pkg/test/random"
 )
+
+const testTimeout = 8 * time.Second
 
 var (
 	globalOrgDAO  *org.DAO

--- a/pkg/queue/mqtt_test.go
+++ b/pkg/queue/mqtt_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/thingspect/atlas/pkg/test/random"
 )
 
+const testTimeout = 5 * time.Second
+
 func TestNewMQTT(t *testing.T) {
 	t.Parallel()
 
@@ -92,7 +94,7 @@ func TestMQTTSubscribe(t *testing.T) {
 		t.Logf("msg.Topic, msg.Payload: %v, %x", msg.Topic(), msg.Payload())
 		require.Equal(t, topic, msg.Topic())
 		require.Equal(t, payload, msg.Payload())
-	case <-time.After(5 * time.Second):
+	case <-time.After(testTimeout):
 		t.Fatal("Message timed out")
 	}
 }
@@ -124,7 +126,7 @@ func TestMQTTUnsubscribe(t *testing.T) {
 		t.Logf("msg, ok: %#v, %v", msg, ok)
 		require.Nil(t, msg)
 		require.False(t, ok)
-	case <-time.After(5 * time.Second):
+	case <-time.After(testTimeout):
 		t.Fatal("Message timed out")
 	}
 }

--- a/pkg/queue/nsq_test.go
+++ b/pkg/queue/nsq_test.go
@@ -94,7 +94,7 @@ func TestNSQSubscribeLookup(t *testing.T) {
 		t.Logf("msg.Topic, msg.Payload: %v, %x", msg.Topic(), msg.Payload())
 		require.Equal(t, topic, msg.Topic())
 		require.Equal(t, payload, msg.Payload())
-	case <-time.After(5 * time.Second):
+	case <-time.After(testTimeout):
 		t.Fatal("Message timed out")
 	}
 }
@@ -123,7 +123,7 @@ func TestNSQSubscribePub(t *testing.T) {
 		t.Logf("msg.Topic, msg.Payload: %v, %x", msg.Topic(), msg.Payload())
 		require.Equal(t, topic, msg.Topic())
 		require.Equal(t, payload, msg.Payload())
-	case <-time.After(5 * time.Second):
+	case <-time.After(testTimeout):
 		t.Fatal("Message timed out")
 	}
 }
@@ -154,7 +154,7 @@ func TestNSQUnsubscribe(t *testing.T) {
 		t.Logf("msg, ok: %#v, %v", msg, ok)
 		require.Nil(t, msg)
 		require.False(t, ok)
-	case <-time.After(5 * time.Second):
+	case <-time.After(testTimeout):
 		t.Fatal("Message timed out")
 	}
 }
@@ -184,7 +184,7 @@ func TestNSQRequeue(t *testing.T) {
 			msg.Payload())
 		require.Equal(t, topic, msg.Topic())
 		require.Equal(t, payload, msg.Payload())
-	case <-time.After(5 * time.Second):
+	case <-time.After(testTimeout):
 		t.Fatal("Requeue message timed out")
 	}
 


### PR DESCRIPTION
- All test variations pass.