### PR TITLE
Further refine attributes for ChirpStack parse functions

### DIFF
--- a/build/deploy/atlas/docker-compose.yml
+++ b/build/deploy/atlas/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   api:
-    image: ghcr.io/thingspect/atlas:610acf36
+    image: ghcr.io/thingspect/atlas:3c7c7d16
     command: api
     ports:
       - "8000:8000"
@@ -12,7 +12,7 @@ services:
       - API_PWT_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
       - API_NSQ_PUB_ADDR=nsqd:4150
   mqtt-ingestor:
-    image: ghcr.io/thingspect/atlas:610acf36
+    image: ghcr.io/thingspect/atlas:3c7c7d16
     command: mqtt-ingestor
     depends_on:
       - validator
@@ -22,7 +22,7 @@ services:
       - MQTT_INGEST_MQTT_PASS=notasecurepassword
       - MQTT_INGEST_NSQ_PUB_ADDR=nsqd:4150
   lora-ingestor:
-    image: ghcr.io/thingspect/atlas:610acf36
+    image: ghcr.io/thingspect/atlas:3c7c7d16
     command: lora-ingestor
     depends_on:
       - validator
@@ -32,7 +32,7 @@ services:
       - LORA_INGEST_MQTT_PASS=notasecurepassword
       - LORA_INGEST_NSQ_PUB_ADDR=nsqd:4150
   validator:
-    image: ghcr.io/thingspect/atlas:610acf36
+    image: ghcr.io/thingspect/atlas:3c7c7d16
     command: validator
     depends_on:
       - accumulator
@@ -42,7 +42,7 @@ services:
       - VALIDATOR_NSQ_LOOKUP_ADDRS=nsqlookupd:4161
       - VALIDATOR_NSQ_PUB_ADDR=nsqd:4150
   accumulator:
-    image: ghcr.io/thingspect/atlas:610acf36
+    image: ghcr.io/thingspect/atlas:3c7c7d16
     command: accumulator
     environment:
       - ACCUMULATOR_STATSD_ADDR=dogstatsd:8125

--- a/internal/accumulator/test/main_test.go
+++ b/internal/accumulator/test/main_test.go
@@ -55,6 +55,7 @@ func TestMain(m *testing.M) {
 		[]byte("acc-aaa")); err != nil {
 		log.Fatalf("TestMain globalVOutQueue.Publish: %v", err)
 	}
+	log.Print("TestMain published throwaway message")
 
 	// Set up Accumulator.
 	acc, err := accumulator.New(cfg)

--- a/internal/lora-ingestor/ingestor/parse_test.go
+++ b/internal/lora-ingestor/ingestor/parse_test.go
@@ -40,8 +40,11 @@ func TestParseGateways(t *testing.T) {
 				ValOneof: &common.DataPoint_StrVal{
 					StrVal: `{"rxInfo":{"rssi":-74}}`}}, SkipToken: true},
 			{Point: &common.DataPoint{UniqId: uniqID, Attr: "lora_rssi",
-				ValOneof: &common.DataPoint_IntVal{
-					IntVal: -74}}, SkipToken: true},
+				ValOneof: &common.DataPoint_IntVal{IntVal: -74}},
+				SkipToken: true},
+			{Point: &common.DataPoint{UniqId: uniqID, Attr: "channel",
+				ValOneof: &common.DataPoint_IntVal{IntVal: 0}},
+				SkipToken: true},
 		}},
 		{"lora/gateway/" + uniqID + "/event/stats", &gw.GatewayStats{
 			RxPacketsReceivedOk: 2}, []*message.ValidatorIn{
@@ -227,6 +230,9 @@ func TestParseDevices(t *testing.T) {
 					StrVal: `{"rxInfo":[{}],"dr":3}`}}, SkipToken: true},
 			{Point: &common.DataPoint{UniqId: uniqID, Attr: "join",
 				ValOneof: &common.DataPoint_BoolVal{BoolVal: true}},
+				SkipToken: true},
+			{Point: &common.DataPoint{UniqId: uniqID, Attr: "channel",
+				ValOneof: &common.DataPoint_IntVal{IntVal: 0}},
 				SkipToken: true},
 			{Point: &common.DataPoint{UniqId: uniqID, Attr: "data_rate",
 				ValOneof: &common.DataPoint_IntVal{IntVal: 3}},

--- a/internal/lora-ingestor/test/ingestor_test.go
+++ b/internal/lora-ingestor/test/ingestor_test.go
@@ -33,8 +33,11 @@ func TestParseGateways(t *testing.T) {
 				ValOneof: &common.DataPoint_StrVal{
 					StrVal: `{"rxInfo":{"rssi":-74}}`}}, SkipToken: true},
 			{Point: &common.DataPoint{UniqId: uniqID, Attr: "lora_rssi",
-				ValOneof: &common.DataPoint_IntVal{
-					IntVal: -74}}, SkipToken: true},
+				ValOneof: &common.DataPoint_IntVal{IntVal: -74}},
+				SkipToken: true},
+			{Point: &common.DataPoint{UniqId: uniqID, Attr: "channel",
+				ValOneof: &common.DataPoint_IntVal{IntVal: 0}},
+				SkipToken: true},
 		}},
 		{"lora/gateway/" + uniqID + "/event/stats", &gw.GatewayStats{
 			RxPacketsReceivedOk: 2}, []*message.ValidatorIn{
@@ -145,6 +148,9 @@ func TestParseDevices(t *testing.T) {
 					StrVal: `{"rxInfo":[{}],"dr":3}`}}, SkipToken: true},
 			{Point: &common.DataPoint{UniqId: uniqID, Attr: "join",
 				ValOneof: &common.DataPoint_BoolVal{BoolVal: true}},
+				SkipToken: true},
+			{Point: &common.DataPoint{UniqId: uniqID, Attr: "channel",
+				ValOneof: &common.DataPoint_IntVal{IntVal: 0}},
 				SkipToken: true},
 			{Point: &common.DataPoint{UniqId: uniqID, Attr: "data_rate",
 				ValOneof: &common.DataPoint_IntVal{IntVal: 3}},

--- a/internal/validator/test/main_test.go
+++ b/internal/validator/test/main_test.go
@@ -64,6 +64,7 @@ func TestMain(m *testing.M) {
 		[]byte("val-aaa")); err != nil {
 		log.Fatalf("TestMain globalVInQueue.Publish: %v", err)
 	}
+	log.Print("TestMain published throwaway message")
 
 	// Set up Validator.
 	val, err := validator.New(cfg)

--- a/pkg/parse/chirpstack/device/device_join.go
+++ b/pkg/parse/chirpstack/device/device_join.go
@@ -77,6 +77,8 @@ func deviceJoin(body []byte) ([]*parse.Point, *timestamppb.Timestamp, error) {
 			msgs = append(msgs, &parse.Point{Attr: "snr",
 				Value: joinMsg.RxInfo[0].LoraSnr})
 		}
+		msgs = append(msgs, &parse.Point{Attr: "channel",
+			Value: int32(joinMsg.RxInfo[0].Channel)})
 	}
 
 	// Parse UplinkTXInfo.

--- a/pkg/parse/chirpstack/device/device_join_test.go
+++ b/pkg/parse/chirpstack/device/device_join_test.go
@@ -65,6 +65,7 @@ func TestDeviceJoin(t *testing.T) {
 			[]*parse.Point{
 				{Attr: "raw_device", Value: `{"rxInfo":[{}]}`},
 				{Attr: "join", Value: true},
+				{Attr: "channel", Value: int32(0)},
 				{Attr: "data_rate", Value: int32(0)},
 			}, time.Now(), ""},
 		{&as.JoinEvent{DevEui: bUniqID, DevAddr: bDevAddr,
@@ -85,6 +86,7 @@ func TestDeviceJoin(t *testing.T) {
 			{Attr: "time", Value: strconv.FormatInt(now.Unix(), 10)},
 			{Attr: "lora_rssi", Value: -74},
 			{Attr: "snr", Value: 7.8},
+			{Attr: "channel", Value: int32(0)},
 			{Attr: "frequency", Value: int32(902700000)},
 			{Attr: "data_rate", Value: int32(3)},
 		}, now, ""},

--- a/pkg/parse/chirpstack/device/device_up.go
+++ b/pkg/parse/chirpstack/device/device_up.go
@@ -70,6 +70,8 @@ func deviceUp(body []byte) ([]*parse.Point, *timestamppb.Timestamp, []byte,
 			msgs = append(msgs, &parse.Point{Attr: "snr",
 				Value: upMsg.RxInfo[0].LoraSnr})
 		}
+		msgs = append(msgs, &parse.Point{Attr: "channel",
+			Value: int32(upMsg.RxInfo[0].Channel)})
 	}
 
 	// Parse UplinkTXInfo.

--- a/pkg/parse/chirpstack/device/device_up_test.go
+++ b/pkg/parse/chirpstack/device/device_up_test.go
@@ -53,6 +53,7 @@ func TestDeviceUp(t *testing.T) {
 		{&as.UplinkEvent{RxInfo: []*gw.UplinkRXInfo{{}}},
 			[]*parse.Point{
 				{Attr: "raw_device", Value: `{"rxInfo":[{}]}`},
+				{Attr: "channel", Value: int32(0)},
 				{Attr: "adr", Value: false},
 				{Attr: "data_rate", Value: int32(0)},
 				{Attr: "confirmed", Value: false},
@@ -72,6 +73,7 @@ func TestDeviceUp(t *testing.T) {
 			{Attr: "time", Value: strconv.FormatInt(now.Unix(), 10)},
 			{Attr: "lora_rssi", Value: -74},
 			{Attr: "snr", Value: 7.8},
+			{Attr: "channel", Value: int32(0)},
 			{Attr: "frequency", Value: int32(902700000)},
 			{Attr: "adr", Value: true},
 			{Attr: "data_rate", Value: int32(3)},

--- a/pkg/parse/chirpstack/gateway/gateway_up.go
+++ b/pkg/parse/chirpstack/gateway/gateway_up.go
@@ -47,16 +47,12 @@ func gatewayUp(body []byte) ([]*parse.Point, error) {
 			msgs = append(msgs, &parse.Point{Attr: "lora_rssi",
 				Value: upMsg.RxInfo.Rssi})
 		}
-
 		if upMsg.RxInfo.LoraSnr != 0 {
 			msgs = append(msgs, &parse.Point{Attr: "snr",
 				Value: upMsg.RxInfo.LoraSnr})
 		}
-
-		if upMsg.RxInfo.Channel != 0 {
-			msgs = append(msgs, &parse.Point{Attr: "channel",
-				Value: int32(upMsg.RxInfo.Channel)})
-		}
+		msgs = append(msgs, &parse.Point{Attr: "channel",
+			Value: int32(upMsg.RxInfo.Channel)})
 	}
 
 	return msgs, nil

--- a/pkg/parse/chirpstack/gateway/gateway_up_test.go
+++ b/pkg/parse/chirpstack/gateway/gateway_up_test.go
@@ -27,6 +27,7 @@ func TestGatewayUp(t *testing.T) {
 		{&gw.UplinkFrame{RxInfo: &gw.UplinkRXInfo{}},
 			[]*parse.Point{
 				{Attr: "raw_gateway", Value: `{"rxInfo":{}}`},
+				{Attr: "channel", Value: int32(0)},
 			}, ""},
 		{&gw.UplinkFrame{TxInfo: &gw.UplinkTXInfo{Frequency: 902700000,
 			ModulationInfo: &gw.UplinkTXInfo_LoraModulationInfo{


### PR DESCRIPTION
- Add `channel` to device, and support channel 0 on both gateway and device.
- All test variations pass.