### PR TITLE
Refactor sentinel errors to be constants

### DIFF
--- a/internal/accumulator/accumulator/accumulate_test.go
+++ b/internal/accumulator/accumulator/accumulate_test.go
@@ -3,7 +3,6 @@
 package accumulator
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -14,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/thingspect/api/go/common"
 	"github.com/thingspect/atlas/api/go/message"
+	"github.com/thingspect/atlas/pkg/consterr"
 	"github.com/thingspect/atlas/pkg/dao"
 	"github.com/thingspect/atlas/pkg/queue"
 	"github.com/thingspect/atlas/pkg/test/matcher"
@@ -22,7 +22,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-var errTestProc = errors.New("accumulator: test processor error")
+const errTestProc consterr.Error = "accumulator: test processor error"
 
 func TestAccumulateMessages(t *testing.T) {
 	t.Parallel()

--- a/internal/api/api/api.go
+++ b/internal/api/api/api.go
@@ -3,7 +3,6 @@ package api
 
 import (
 	"context"
-	"errors"
 	"net"
 	"net/http"
 	"os"
@@ -18,6 +17,7 @@ import (
 	"github.com/thingspect/atlas/internal/api/lora"
 	"github.com/thingspect/atlas/internal/api/service"
 	"github.com/thingspect/atlas/pkg/alog"
+	"github.com/thingspect/atlas/pkg/consterr"
 	"github.com/thingspect/atlas/pkg/dao"
 	"github.com/thingspect/atlas/pkg/dao/datapoint"
 	"github.com/thingspect/atlas/pkg/dao/device"
@@ -38,9 +38,9 @@ const (
 	GRPCHost    = "127.0.0.1"
 	GRPCPort    = ":50051"
 	httpPort    = ":8000"
-)
 
-var errPWTLength = errors.New("pwt key must be 32 bytes")
+	errPWTLength consterr.Error = "pwt key must be 32 bytes"
+)
 
 // API holds references to the gRPC and HTTP servers.
 type API struct {

--- a/internal/api/crypto/encrypt.go
+++ b/internal/api/crypto/encrypt.go
@@ -4,21 +4,18 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
-	"errors"
+
+	"github.com/thingspect/atlas/pkg/consterr"
 )
 
-var (
-	ErrKeyLength = errors.New("crypto: incorrect key length")
-	ErrMalformed = errors.New("crypto: malformed ciphertext")
+const (
+	ErrKeyLength consterr.Error = "crypto: incorrect key length"
+	ErrMalformed consterr.Error = "crypto: malformed ciphertext"
 )
 
 // Encrypt encrypts data using 256-bit AES-GCM, providing authenticated
 // encryption with associated data.
-//
-// Resources:
-//
 // https://github.com/gtank/cryptopasta
-//
 // https://golang.org/pkg/crypto/cipher/#NewGCM
 func Encrypt(key []byte, plaintext []byte) ([]byte, error) {
 	if len(key) != 32 {

--- a/internal/api/crypto/password.go
+++ b/internal/api/crypto/password.go
@@ -2,13 +2,13 @@
 package crypto
 
 import (
-	"errors"
 	"strings"
 
+	"github.com/thingspect/atlas/pkg/consterr"
 	"golang.org/x/crypto/bcrypt"
 )
 
-var ErrWeakPass = errors.New("weak password, see NIST password guidelines")
+const ErrWeakPass consterr.Error = "weak password, see NIST password guidelines"
 
 // CheckPass checks whether a password is weak or disallowed.
 func CheckPass(pass string) error {

--- a/internal/api/session/web_token.go
+++ b/internal/api/session/web_token.go
@@ -2,21 +2,24 @@ package session
 
 import (
 	"encoding/base64"
-	"errors"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/thingspect/api/go/api"
 	"github.com/thingspect/atlas/api/go/token"
 	"github.com/thingspect/atlas/internal/api/crypto"
+	"github.com/thingspect/atlas/pkg/consterr"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-// WebTokenExp represents the lifetime of a web token in seconds.
-const WebTokenExp = 10 * 60
+const (
+	// WebTokenExp represents the lifetime of a web token in seconds.
+	WebTokenExp = 10 * 60
 
-var errWebTokenExp = errors.New("crypto: token expired")
+	//#nosec G101 // false positive for hardcoded credentials
+	errWebTokenExp consterr.Error = "crypto: token expired"
+)
 
 // GenerateWebToken generates an encrypted protobuf web token in raw (no
 // padding) base64 format. It returns the token, expiration time, and an error

--- a/internal/decoder/decoder/decode_test.go
+++ b/internal/decoder/decoder/decode_test.go
@@ -3,7 +3,6 @@
 package decoder
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -13,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/thingspect/api/go/common"
 	"github.com/thingspect/atlas/api/go/message"
+	"github.com/thingspect/atlas/pkg/consterr"
 	"github.com/thingspect/atlas/pkg/dao"
 	"github.com/thingspect/atlas/pkg/decode/registry"
 	"github.com/thingspect/atlas/pkg/queue"
@@ -21,7 +21,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-var errTestProc = errors.New("decoder: test processor error")
+const errTestProc consterr.Error = "decoder: test processor error"
 
 func TestDecodeMessages(t *testing.T) {
 	t.Parallel()

--- a/internal/eventer/eventer/event_test.go
+++ b/internal/eventer/eventer/event_test.go
@@ -3,7 +3,6 @@
 package eventer
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -14,6 +13,7 @@ import (
 	"github.com/thingspect/api/go/api"
 	"github.com/thingspect/api/go/common"
 	"github.com/thingspect/atlas/api/go/message"
+	"github.com/thingspect/atlas/pkg/consterr"
 	"github.com/thingspect/atlas/pkg/dao"
 	"github.com/thingspect/atlas/pkg/queue"
 	"github.com/thingspect/atlas/pkg/test/matcher"
@@ -22,7 +22,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-var errTestProc = errors.New("eventer: test processor error")
+const errTestProc consterr.Error = "eventer: test processor error"
 
 func TestEventMessages(t *testing.T) {
 	t.Parallel()

--- a/internal/validator/validator/validate_test.go
+++ b/internal/validator/validator/validate_test.go
@@ -3,7 +3,6 @@
 package validator
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -13,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/thingspect/api/go/common"
 	"github.com/thingspect/atlas/api/go/message"
+	"github.com/thingspect/atlas/pkg/consterr"
 	"github.com/thingspect/atlas/pkg/dao"
 	"github.com/thingspect/atlas/pkg/queue"
 	"github.com/thingspect/atlas/pkg/test/random"
@@ -20,7 +20,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-var errTestProc = errors.New("validator: test processor error")
+const errTestProc consterr.Error = "validator: test processor error"
 
 func TestValidateMessages(t *testing.T) {
 	t.Parallel()

--- a/pkg/consterr/consterr.go
+++ b/pkg/consterr/consterr.go
@@ -1,0 +1,11 @@
+// Package consterr provides types and functions to create constant errors.
+package consterr
+
+// Error supports constant errors and implements the error interface.
+type Error string
+
+// Verify Error implements error.
+var _ error = new(Error)
+
+// Error returns the error.
+func (e Error) Error() string { return string(e) }

--- a/pkg/consterr/consterr_test.go
+++ b/pkg/consterr/consterr_test.go
@@ -1,0 +1,38 @@
+// +build !integration
+
+package consterr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/thingspect/atlas/pkg/test/random"
+)
+
+func TestOrg(t *testing.T) {
+	t.Parallel()
+
+	for i := 0; i < 5; i++ {
+		lTest := i
+
+		t.Run(fmt.Sprintf("Can error %v", lTest), func(t *testing.T) {
+			t.Parallel()
+
+			errStr := random.String(10)
+
+			err := Error(errStr)
+			t.Logf("err: %v", err)
+			// Verify err implements error.
+			var _ error = err
+
+			require.Equal(t, errStr, err.Error())
+			// Errors should compare exactly without reflection.
+			require.True(t, err == Error(errStr))
+
+			wrapErr := fmt.Errorf("%w: %s", err, random.String(10))
+			t.Logf("wrapErr: %v", wrapErr)
+			require.ErrorIs(t, wrapErr, err)
+		})
+	}
+}

--- a/pkg/dao/error.go
+++ b/pkg/dao/error.go
@@ -10,13 +10,14 @@ import (
 
 	"github.com/jackc/pgconn"
 	"github.com/thingspect/atlas/pkg/alog"
+	"github.com/thingspect/atlas/pkg/consterr"
 )
 
 // Sentinel errors for DAO packages.
-var (
-	ErrAlreadyExists = errors.New("object already exists")
-	ErrInvalidFormat = errors.New("invalid format")
-	ErrNotFound      = errors.New("object not found")
+const (
+	ErrAlreadyExists consterr.Error = "object already exists"
+	ErrInvalidFormat consterr.Error = "invalid format"
+	ErrNotFound      consterr.Error = "object not found"
 )
 
 // DBToSentinel maps database/sql or driver errors to sentinel errors. This

--- a/pkg/decode/decode.go
+++ b/pkg/decode/decode.go
@@ -3,8 +3,9 @@
 package decode
 
 import (
-	"errors"
 	"time"
+
+	"github.com/thingspect/atlas/pkg/consterr"
 )
 
 // ValidWindow is the window that a payload's timestamp is considered valid.
@@ -13,7 +14,7 @@ import (
 // has bogus time.
 const ValidWindow = 4 * time.Hour
 
-var ErrUnknownEvent = errors.New("unknown event type")
+const ErrUnknownEvent consterr.Error = "unknown event type"
 
 // Point represents an attribute-value pair as produced by a decoder function.
 // Values should conform to common.DataPoint types, specifically int32, float64,

--- a/pkg/decode/error.go
+++ b/pkg/decode/error.go
@@ -1,11 +1,12 @@
 package decode
 
 import (
-	"errors"
 	"fmt"
+
+	"github.com/thingspect/atlas/pkg/consterr"
 )
 
-var errFormat = errors.New("format")
+const errFormat consterr.Error = "format"
 
 // ErrFormat returns an error due to a malformed payload.
 func ErrFormat(function string, reason string, body []byte) error {

--- a/pkg/decode/registry/registry.go
+++ b/pkg/decode/registry/registry.go
@@ -2,15 +2,15 @@
 package registry
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/thingspect/api/go/common"
+	"github.com/thingspect/atlas/pkg/consterr"
 	"github.com/thingspect/atlas/pkg/decode"
 	"github.com/thingspect/atlas/pkg/decode/radiobridge"
 )
 
-var ErrNotFound = errors.New("decoder function not found")
+const ErrNotFound consterr.Error = "decoder function not found"
 
 // Registry holds decoder-function mappings.
 type Registry struct {

--- a/pkg/queue/mqtt.go
+++ b/pkg/queue/mqtt.go
@@ -1,19 +1,19 @@
 package queue
 
 import (
-	"errors"
 	"log"
 	"time"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
+	"github.com/thingspect/atlas/pkg/consterr"
 )
 
 const (
 	DefaultMQTTConnectTimeout = 5 * time.Second
 	mqttPublishTimeout        = 30 * time.Second
-)
 
-var ErrTimeout = errors.New("queue: timed out")
+	ErrTimeout consterr.Error = "queue: timed out"
+)
 
 // mqttQueue contains methods to publish and subscribe to MQTT and implements
 // the Queuer interface.

--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -2,16 +2,16 @@
 package rule
 
 import (
-	"errors"
 	"time"
 
 	"github.com/antonmedv/expr"
 	"github.com/thingspect/api/go/common"
+	"github.com/thingspect/atlas/pkg/consterr"
 )
 
-var ErrNotBool = errors.New("not a boolean expression")
+const ErrNotBool consterr.Error = "not a boolean expression"
 
-// Eval evaluates a boolean expression using the Expr language.
+// Eval evaluates a boolean expression using the Expr language:
 // https://github.com/antonmedv/expr/blob/master/docs/Language-Definition.md
 func Eval(point *common.DataPoint, ruleExpr string) (bool, error) {
 	env := map[string]interface{}{


### PR DESCRIPTION
- Add `pkg/consterr` to support constant errors.
- All test variations pass.