### PR TITLE
Add Prime() to the Queuer interface to prime a Queue topic

### DIFF
--- a/internal/accumulator/accumulator/accumulator.go
+++ b/internal/accumulator/accumulator/accumulator.go
@@ -50,6 +50,11 @@ func New(cfg *config.Config) (*Accumulator, error) {
 		return nil, err
 	}
 
+	// Prime the queue before subscribing to allow for discovery by nsqlookupd.
+	if err = nsq.Prime(cfg.NSQSubTopic); err != nil {
+		return nil, err
+	}
+
 	// Subscribe to the topic.
 	vOutSub, err := nsq.Subscribe(cfg.NSQSubTopic)
 	if err != nil {

--- a/internal/accumulator/test/main_test.go
+++ b/internal/accumulator/test/main_test.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/thingspect/atlas/internal/accumulator/accumulator"
 	"github.com/thingspect/atlas/internal/accumulator/config"
@@ -50,15 +49,6 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatalf("TestMain queue.NewNSQ: %v", err)
 	}
-
-	// Publish a throwaway message before subscribe to allow for discovery by
-	// nsqlookupd.
-	if err = globalAccQueue.Publish(cfg.NSQSubTopic,
-		[]byte("acc-aaa")); err != nil {
-		log.Fatalf("TestMain globalAccQueue.Publish: %v", err)
-	}
-	time.Sleep(100 * time.Millisecond)
-	log.Print("TestMain published throwaway message")
 
 	// Set up Accumulator.
 	acc, err := accumulator.New(cfg)

--- a/internal/alerter/alerter/alert.go
+++ b/internal/alerter/alerter/alert.go
@@ -1,6 +1,7 @@
 package alerter
 
 import (
+	"bytes"
 	"context"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/thingspect/atlas/pkg/alog"
 	"github.com/thingspect/atlas/pkg/consterr"
 	"github.com/thingspect/atlas/pkg/metric"
+	"github.com/thingspect/atlas/pkg/queue"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -30,9 +32,12 @@ func (ale *Alerter) alertMessages() {
 		if err != nil || eOut.Point == nil || eOut.Device == nil ||
 			eOut.Rule == nil {
 			msg.Ack()
-			metric.Incr("error", map[string]string{"func": "unmarshal"})
-			alog.Errorf("alertMessages proto.Unmarshal eOut, err: %+v, %v",
-				eOut, err)
+
+			if !bytes.Equal([]byte{queue.Prime}, msg.Payload()) {
+				metric.Incr("error", map[string]string{"func": "unmarshal"})
+				alog.Errorf("alertMessages proto.Unmarshal eOut, err: %+v, %v",
+					eOut, err)
+			}
 
 			continue
 		}

--- a/internal/alerter/alerter/alerter.go
+++ b/internal/alerter/alerter/alerter.go
@@ -86,6 +86,11 @@ func New(cfg *config.Config) (*Alerter, error) {
 		return nil, err
 	}
 
+	// Prime the queue before subscribing to allow for discovery by nsqlookupd.
+	if err = nsq.Prime(cfg.NSQSubTopic); err != nil {
+		return nil, err
+	}
+
 	// Subscribe to the topic.
 	eOutSub, err := nsq.Subscribe(cfg.NSQSubTopic)
 	if err != nil {

--- a/internal/alerter/test/main_test.go
+++ b/internal/alerter/test/main_test.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/thingspect/atlas/internal/alerter/alerter"
 	"github.com/thingspect/atlas/internal/alerter/config"
@@ -55,15 +54,6 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatalf("TestMain queue.NewNSQ: %v", err)
 	}
-
-	// Publish a throwaway message before subscribe to allow for discovery by
-	// nsqlookupd.
-	if err = globalAleQueue.Publish(cfg.NSQSubTopic,
-		[]byte("ale-aaa")); err != nil {
-		log.Fatalf("TestMain globalAleQueue.Publish: %v", err)
-	}
-	time.Sleep(100 * time.Millisecond)
-	log.Print("TestMain published throwaway message")
 
 	// Set up Alerter.
 	ale, err := alerter.New(cfg)

--- a/internal/decoder/decoder/decoder.go
+++ b/internal/decoder/decoder/decoder.go
@@ -52,6 +52,11 @@ func New(cfg *config.Config) (*Decoder, error) {
 		return nil, err
 	}
 
+	// Prime the queue before subscribing to allow for discovery by nsqlookupd.
+	if err = nsq.Prime(cfg.NSQSubTopic); err != nil {
+		return nil, err
+	}
+
 	// Subscribe to the topic.
 	dInSub, err := nsq.Subscribe(cfg.NSQSubTopic)
 	if err != nil {

--- a/internal/decoder/test/main_test.go
+++ b/internal/decoder/test/main_test.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/thingspect/atlas/internal/decoder/config"
 	"github.com/thingspect/atlas/internal/decoder/decoder"
@@ -55,15 +54,6 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatalf("TestMain queue.NewNSQ: %v", err)
 	}
-
-	// Publish a throwaway message before subscribe to allow for discovery by
-	// nsqlookupd.
-	if err = globalDecQueue.Publish(cfg.NSQSubTopic,
-		[]byte("dec-aaa")); err != nil {
-		log.Fatalf("TestMain globalDecQueue.Publish: %v", err)
-	}
-	time.Sleep(100 * time.Millisecond)
-	log.Print("TestMain published throwaway message")
 
 	// Set up Decoder.
 	dec, err := decoder.New(cfg)

--- a/internal/eventer/eventer/eventer.go
+++ b/internal/eventer/eventer/eventer.go
@@ -59,6 +59,11 @@ func New(cfg *config.Config) (*Eventer, error) {
 		return nil, err
 	}
 
+	// Prime the queue before subscribing to allow for discovery by nsqlookupd.
+	if err = nsq.Prime(cfg.NSQSubTopic); err != nil {
+		return nil, err
+	}
+
 	// Subscribe to the topic.
 	vOutSub, err := nsq.Subscribe(cfg.NSQSubTopic)
 	if err != nil {

--- a/internal/eventer/test/main_test.go
+++ b/internal/eventer/test/main_test.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/thingspect/atlas/internal/eventer/config"
 	"github.com/thingspect/atlas/internal/eventer/eventer"
@@ -59,15 +58,6 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatalf("TestMain queue.NewNSQ: %v", err)
 	}
-
-	// Publish a throwaway message before subscribe to allow for discovery by
-	// nsqlookupd.
-	if err = globalEvQueue.Publish(cfg.NSQSubTopic,
-		[]byte("ev-aaa")); err != nil {
-		log.Fatalf("TestMain globalEvQueue.Publish: %v", err)
-	}
-	time.Sleep(100 * time.Millisecond)
-	log.Print("TestMain published throwaway message")
 
 	// Set up Eventer.
 	ev, err := eventer.New(cfg)

--- a/internal/validator/test/main_test.go
+++ b/internal/validator/test/main_test.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/thingspect/atlas/internal/validator/config"
 	"github.com/thingspect/atlas/internal/validator/validator"
@@ -55,15 +54,6 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatalf("TestMain queue.NewNSQ: %v", err)
 	}
-
-	// Publish a throwaway message before subscribe to allow for discovery by
-	// nsqlookupd.
-	if err = globalValQueue.Publish(cfg.NSQSubTopic,
-		[]byte("val-aaa")); err != nil {
-		log.Fatalf("TestMain globalValQueue.Publish: %v", err)
-	}
-	time.Sleep(100 * time.Millisecond)
-	log.Print("TestMain published throwaway message")
 
 	// Set up Validator.
 	val, err := validator.New(cfg)

--- a/internal/validator/validator/validator.go
+++ b/internal/validator/validator/validator.go
@@ -50,6 +50,11 @@ func New(cfg *config.Config) (*Validator, error) {
 		return nil, err
 	}
 
+	// Prime the queue before subscribing to allow for discovery by nsqlookupd.
+	if err = nsq.Prime(cfg.NSQSubTopic); err != nil {
+		return nil, err
+	}
+
 	// Subscribe to the topic.
 	vInSub, err := nsq.Subscribe(cfg.NSQSubTopic)
 	if err != nil {

--- a/pkg/queue/fake.go
+++ b/pkg/queue/fake.go
@@ -50,6 +50,12 @@ func (f *fakeQueue) Publish(topic string, payload []byte) error {
 	return nil
 }
 
+// Prime primes a Queue topic by publishing a single-byte message, with value
+// Prime, for the purpose of being discarded.
+func (f *fakeQueue) Prime(topic string) error {
+	return f.Publish(topic, []byte{Prime})
+}
+
 // fakeSub contains methods to read from a subscription and implements the
 // Subber interface.
 type fakeSub struct {

--- a/pkg/queue/fake_test.go
+++ b/pkg/queue/fake_test.go
@@ -23,7 +23,7 @@ func TestFakePublish(t *testing.T) {
 func TestFakeSubscribe(t *testing.T) {
 	t.Parallel()
 
-	topic := "testFakeSubscribePub-" + random.String(10)
+	topic := "testFakeSubscribe-" + random.String(10)
 	payload := random.Bytes(10)
 
 	fake := NewFake()
@@ -41,6 +41,31 @@ func TestFakeSubscribe(t *testing.T) {
 		t.Logf("msg.Topic, msg.Payload: %v, %x", msg.Topic(), msg.Payload())
 		require.Equal(t, topic, msg.Topic())
 		require.Equal(t, payload, msg.Payload())
+	case <-time.After(2 * time.Second):
+		t.Fatal("Message timed out")
+	}
+}
+
+func TestFakePrime(t *testing.T) {
+	t.Parallel()
+
+	topic := "testFakePrime-" + random.String(10)
+
+	fake := NewFake()
+	t.Logf("fake: %+v", fake)
+
+	sub, err := fake.Subscribe(topic)
+	t.Logf("sub, err: %+v, %v", sub, err)
+	require.NoError(t, err)
+
+	require.NoError(t, fake.Prime(topic))
+
+	select {
+	case msg := <-sub.C():
+		msg.Ack()
+		t.Logf("msg.Topic, msg.Payload: %v, %x", msg.Topic(), msg.Payload())
+		require.Equal(t, topic, msg.Topic())
+		require.Equal(t, []byte{Prime}, msg.Payload())
 	case <-time.After(2 * time.Second):
 		t.Fatal("Message timed out")
 	}

--- a/pkg/queue/mqtt.go
+++ b/pkg/queue/mqtt.go
@@ -60,6 +60,12 @@ func (m *mqttQueue) Publish(topic string, payload []byte) error {
 	return token.Error()
 }
 
+// Prime primes a Queue topic by publishing a single-byte message, with value
+// Prime, for the purpose of being discarded.
+func (m *mqttQueue) Prime(topic string) error {
+	return m.Publish(topic, []byte{Prime})
+}
+
 // mqttSub contains methods to read from a subscription and implements the
 // Subber interface.
 type mqttSub struct {

--- a/pkg/queue/nsq.go
+++ b/pkg/queue/nsq.go
@@ -56,6 +56,15 @@ func (n *nsqQueue) Publish(topic string, payload []byte) error {
 	return n.producer.Publish(topic, payload)
 }
 
+// Prime primes a Queue topic by publishing a single-byte message, with value
+// Prime, for the purpose of being discarded.
+func (n *nsqQueue) Prime(topic string) error {
+	err := n.Publish(topic, []byte{Prime})
+	time.Sleep(100 * time.Millisecond)
+
+	return err
+}
+
 // nsqSub contains methods to read from a subscription and implements the Subber
 // interface.
 type nsqSub struct {

--- a/pkg/queue/queuer.go
+++ b/pkg/queue/queuer.go
@@ -1,6 +1,8 @@
 // Package queue provides functions to publish and subscribe to queues.
 package queue
 
+const Prime = 0x00
+
 // Messager defines the methods provided by a Message. Messages are not
 // guaranteed to be thread-safe, and should only be accessed by their methods.
 type Messager interface {
@@ -33,4 +35,7 @@ type Queuer interface {
 	Subscribe(topic string) (Subber, error)
 	// Disconnect ends the connection to a Queue.
 	Disconnect()
+	// Prime primes a Queue topic by publishing a single-byte message, with
+	// value Prime, for the purpose of being discarded.
+	Prime(topic string) error
 }


### PR DESCRIPTION
- Update services that consume from NSQ to prime on start, and remove manual priming from `main_test.go`.
- All test variations pass.