### PR TITLE
Convert MQTT client to manual Ack()

### DIFF
--- a/build/deploy/atlas/docker-compose.yml
+++ b/build/deploy/atlas/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   atlas-api:
-    image: ghcr.io/thingspect/atlas:2791f1f9
+    image: ghcr.io/thingspect/atlas:53b09ce0
     command: atlas-api
     restart: on-failure
     ports:
@@ -20,7 +20,7 @@ services:
       - API_LORA_DEV_PROF_ID=00000000-0000-0000-0000-000000000000
 
   atlas-mqtt-ingestor:
-    image: ghcr.io/thingspect/atlas:2791f1f9
+    image: ghcr.io/thingspect/atlas:53b09ce0
     command: atlas-mqtt-ingestor
     restart: on-failure
     depends_on:
@@ -32,7 +32,7 @@ services:
       - MQTT_INGEST_NSQ_PUB_ADDR=nsqd:4150
 
   atlas-lora-ingestor:
-    image: ghcr.io/thingspect/atlas:2791f1f9
+    image: ghcr.io/thingspect/atlas:53b09ce0
     command: atlas-lora-ingestor
     restart: on-failure
     depends_on:
@@ -45,7 +45,7 @@ services:
       - LORA_INGEST_NSQ_PUB_ADDR=nsqd:4150
 
   atlas-decoder:
-    image: ghcr.io/thingspect/atlas:2791f1f9
+    image: ghcr.io/thingspect/atlas:53b09ce0
     command: atlas-decoder
     restart: on-failure
     depends_on:
@@ -57,7 +57,7 @@ services:
       - DECODER_NSQ_LOOKUP_ADDRS=nsqlookupd:4161
 
   atlas-validator:
-    image: ghcr.io/thingspect/atlas:2791f1f9
+    image: ghcr.io/thingspect/atlas:53b09ce0
     command: atlas-validator
     restart: on-failure
     depends_on:
@@ -70,7 +70,7 @@ services:
       - VALIDATOR_NSQ_LOOKUP_ADDRS=nsqlookupd:4161
 
   atlas-accumulator:
-    image: ghcr.io/thingspect/atlas:2791f1f9
+    image: ghcr.io/thingspect/atlas:53b09ce0
     command: atlas-accumulator
     restart: on-failure
     environment:
@@ -80,7 +80,7 @@ services:
       - ACCUMULATOR_NSQ_LOOKUP_ADDRS=nsqlookupd:4161
 
   atlas-eventer:
-    image: ghcr.io/thingspect/atlas:2791f1f9
+    image: ghcr.io/thingspect/atlas:53b09ce0
     command: atlas-eventer
     restart: on-failure
     depends_on:
@@ -92,7 +92,7 @@ services:
       - EVENTER_NSQ_LOOKUP_ADDRS=nsqlookupd:4161
 
   atlas-alerter:
-    image: ghcr.io/thingspect/atlas:2791f1f9
+    image: ghcr.io/thingspect/atlas:53b09ce0
     command: atlas-alerter
     restart: on-failure
     environment:

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ReneKroon/ttlcache/v3 v3.0.0-beta
 	github.com/antonmedv/expr v1.9.0
 	github.com/chirpstack/chirpstack/api/go/v4 v4.0.2
-	github.com/eclipse/paho.mqtt.golang v1.4.1
+	github.com/eclipse/paho.mqtt.golang v1.4.2
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.3.0
@@ -47,6 +47,6 @@ require (
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/text v0.4.0 // indirect
-	google.golang.org/genproto v0.0.0-20221024153911-1573dae28c9c // indirect
+	google.golang.org/genproto v0.0.0-20221025140454-527a21cfbd71 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
-github.com/eclipse/paho.mqtt.golang v1.4.1 h1:tUSpviiL5G3P9SZZJPC4ZULZJsxQKXxfENpMvdbAXAI=
-github.com/eclipse/paho.mqtt.golang v1.4.1/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
+github.com/eclipse/paho.mqtt.golang v1.4.2 h1:66wOzfUHSSI1zamx7jR6yMEI5EuHnT1G6rNA5PM12m4=
+github.com/eclipse/paho.mqtt.golang v1.4.2/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -654,8 +654,8 @@ google.golang.org/genproto v0.0.0-20201210142538-e3217bee35cc/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20201214200347-8c77b98c765d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210108203827-ffc7fda8c3d7/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210226172003-ab064af71705/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto v0.0.0-20221024153911-1573dae28c9c h1:+o+fjzgkPaHAQDdk5gGX4DZF99huQ0BMqgOqx4SwyJw=
-google.golang.org/genproto v0.0.0-20221024153911-1573dae28c9c/go.mod h1:9qHF0xnpdSfF6knlcsnpzUu5y+rpwgbvsyGAZPBMg4s=
+google.golang.org/genproto v0.0.0-20221025140454-527a21cfbd71 h1:GEgb2jF5zxsFJpJfg9RoDDWm7tiwc/DDSTE2BtLUkXU=
+google.golang.org/genproto v0.0.0-20221025140454-527a21cfbd71/go.mod h1:9qHF0xnpdSfF6knlcsnpzUu5y+rpwgbvsyGAZPBMg4s=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=

--- a/internal/atlas-decoder/decoder/decode.go
+++ b/internal/atlas-decoder/decoder/decode.go
@@ -71,6 +71,7 @@ func (dec *Decoder) decodeMessages() {
 			metric.Incr("error", map[string]string{"func": "decode"})
 			logger.Errorf("decodeMessages dec.registry.Decode: %v", err)
 		}
+		metric.Incr("processed", nil)
 		logger.Debugf("decodeMessages points: %+v", points)
 
 		// Build and publish ValidatorIn messages.
@@ -100,11 +101,10 @@ func (dec *Decoder) decodeMessages() {
 			logger.Debugf("decodeMessages published: %+v", vIn)
 		}
 
-		// Do not ack on errors, as publish may retry successfully.
+		// Do not ack on points loop errors, as publish may retry successfully.
 		// Deduplication will take place downstream.
 		if successCount == len(points) {
 			msg.Ack()
-			metric.Incr("processed", nil)
 		}
 
 		processCount++

--- a/internal/atlas-lora-ingestor/ingestor/decode.go
+++ b/internal/atlas-lora-ingestor/ingestor/decode.go
@@ -20,7 +20,6 @@ func (ing *Ingestor) decodeGateways() {
 
 	var processCount int
 	for msg := range ing.mqttGWSub.C() {
-		msg.Ack()
 		metric.Incr("received", map[string]string{"type": "gateway"})
 
 		// Set up logging fields.
@@ -37,6 +36,7 @@ func (ing *Ingestor) decodeGateways() {
 			topicParts[0] != "lora" ||
 			topicParts[2] != "gateway" ||
 			(topicParts[4] != "event" && topicParts[4] != "state") {
+			msg.Ack()
 			metric.Incr("error", map[string]string{"func": "topic"})
 			logger.Errorf("decodeGateways unknown topic: %v", topic)
 
@@ -62,6 +62,7 @@ func (ing *Ingestor) decodeGateways() {
 
 			bVIn, err := proto.Marshal(vIn)
 			if err != nil {
+				msg.Ack()
 				metric.Incr("error", map[string]string{"func": "marshal"})
 				logger.Errorf("decodeGateways proto.Marshal: %v", err)
 
@@ -70,6 +71,7 @@ func (ing *Ingestor) decodeGateways() {
 
 			if err = ing.ingQueue.Publish(ing.vInGWPubTopic,
 				bVIn); err != nil {
+				// Allow requeue.
 				metric.Incr("error", map[string]string{"func": "publish"})
 				logger.Errorf("decodeGateways ing.decoderQueue.Publish: %v",
 					err)
@@ -81,6 +83,7 @@ func (ing *Ingestor) decodeGateways() {
 			logger.Debugf("decodeGateways published: %+v", vIn)
 		}
 
+		msg.Ack()
 		processCount++
 		if processCount%100 == 0 {
 			alog.Infof("decodeGateways processed %v messages", processCount)
@@ -94,7 +97,6 @@ func (ing *Ingestor) decodeDevices() {
 
 	var processCount int
 	for msg := range ing.mqttDevSub.C() {
-		msg.Ack()
 		metric.Incr("received", map[string]string{"type": "device"})
 
 		// Set up logging fields.
@@ -110,6 +112,7 @@ func (ing *Ingestor) decodeDevices() {
 		if len(topicParts) != 7 || topicParts[0] != "lora" ||
 			topicParts[1] != "application" || topicParts[3] != "device" ||
 			topicParts[5] != "event" {
+			msg.Ack()
 			metric.Incr("error", map[string]string{"func": "topic"})
 			logger.Errorf("decodeDevices unknown topic: %v", topic)
 
@@ -129,6 +132,9 @@ func (ing *Ingestor) decodeDevices() {
 		logger.Debugf("decodeDevices points: %+v", points)
 
 		// Build and publish ValidatorIn messages.
+		successTarget := len(points)
+		var successCount int
+
 		for _, point := range points {
 			vIn := registry.PointToVIn(traceID, topicParts[4], point, ts)
 
@@ -149,12 +155,14 @@ func (ing *Ingestor) decodeDevices() {
 				continue
 			}
 
+			successCount++
 			metric.Incr("published", map[string]string{"type": "device"})
 			logger.Debugf("decodeDevices point published: %+v", vIn)
 		}
 
 		// Build and publish DecoderIn messages, if present.
 		if len(data) > 0 {
+			successTarget++
 			pIn := &message.DecoderIn{
 				UniqId:  topicParts[4],
 				Data:    data,
@@ -164,6 +172,7 @@ func (ing *Ingestor) decodeDevices() {
 
 			bPIn, err := proto.Marshal(pIn)
 			if err != nil {
+				msg.Ack()
 				metric.Incr("error", map[string]string{"func": "marshal"})
 				logger.Errorf("decodeDevices data proto.Marshal: %v", err)
 
@@ -172,6 +181,7 @@ func (ing *Ingestor) decodeDevices() {
 
 			if err = ing.ingQueue.Publish(ing.dInPubTopic,
 				bPIn); err != nil {
+				// Allow requeue.
 				metric.Incr("error", map[string]string{"func": "publish"})
 				logger.Errorf("decodeDevices data ing.decoderQueue.Publish: %v",
 					err)
@@ -179,8 +189,15 @@ func (ing *Ingestor) decodeDevices() {
 				continue
 			}
 
+			successCount++
 			metric.Incr("published", map[string]string{"type": "data"})
 			logger.Debugf("decodeDevices data published: %+v", pIn)
+		}
+
+		// Do not ack on points loop errors, as publish may retry successfully.
+		// Deduplication will take place downstream.
+		if successCount == successTarget {
+			msg.Ack()
 		}
 
 		processCount++

--- a/pkg/queue/mqtt.go
+++ b/pkg/queue/mqtt.go
@@ -1,10 +1,10 @@
 package queue
 
 import (
-	"log"
 	"time"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
+	"github.com/thingspect/atlas/pkg/alog"
 	"github.com/thingspect/atlas/pkg/consterr"
 )
 
@@ -39,7 +39,8 @@ func NewMQTT(addr, user, pass, clientID string, connectTimeout time.Duration) (
 		SetPassword(pass).
 		SetClientID(clientID).
 		SetOrderMatters(false).
-		SetMaxReconnectInterval(connectTimeout)
+		SetMaxReconnectInterval(connectTimeout).
+		SetAutoAckDisabled(true)
 	client := mqtt.NewClient(opts)
 
 	token := client.Connect()
@@ -111,7 +112,7 @@ var _ Messager = &mqttMessage{}
 
 // Requeue is not supported.
 func (mm *mqttMessage) Requeue() {
-	log.Fatal("Requeue unsupported")
+	alog.Fatal("Requeue unsupported")
 }
 
 // Subscribe subscribes to a topic and returns a Subber and an error value.

--- a/pkg/queue/queuer.go
+++ b/pkg/queue/queuer.go
@@ -13,12 +13,14 @@ type Messager interface {
 	Topic() string
 	// Payload returns the Messager's payload.
 	Payload() []byte
-	// Ack acknowledges successful processing of a Messager. For an MQTT
-	// Messager, this is performed automatically.
+	// Ack acknowledges successful processing of a Messager.
 	Ack()
 	// Requeue requeues a Messager using a per-message backoff based on the
 	// number of attempts. Requeue should only be used with transient failures
-	// that are likely to resolve. Requeue is not supported by MQTT.
+	// that are likely to resolve.
+	//
+	// Requeue is not supported by MQTT, allow messages to automatically requeue
+	// in the absence of an Ack instead.
 	Requeue()
 }
 

--- a/vendor/github.com/eclipse/paho.mqtt.golang/client.go
+++ b/vendor/github.com/eclipse/paho.mqtt.golang/client.go
@@ -38,13 +38,6 @@ import (
 	"github.com/eclipse/paho.mqtt.golang/packets"
 )
 
-const (
-	disconnected uint32 = iota
-	connecting
-	reconnecting
-	connected
-)
-
 // Client is the interface definition for a Client as used by this
 // library, the interface is primarily to allow mocking tests.
 //
@@ -52,9 +45,12 @@ const (
 // with an MQTT server using non-blocking methods that allow work
 // to be done in the background.
 // An application may connect to an MQTT server using:
-//   A plain TCP socket
-//   A secure SSL/TLS socket
-//   A websocket
+//
+//		A plain TCP socket (e.g. mqtt://test.mosquitto.org:1833)
+//		A secure SSL/TLS socket (e.g. tls://test.mosquitto.org:8883)
+//		A websocket (e.g ws://test.mosquitto.org:8080 or wss://test.mosquitto.org:8081)
+//	 Something else (using `options.CustomOpenConnectionFn`)
+//
 // To enable ensured message delivery at Quality of Service (QoS) levels
 // described in the MQTT spec, a message persistence mechanism must be
 // used. This is done by providing a type which implements the Store
@@ -128,8 +124,7 @@ type client struct {
 	lastReceived    atomic.Value // time.Time - the last time a packet was successfully received from network
 	pingOutstanding int32        // set to 1 if a ping has been sent but response not ret received
 
-	status       uint32 // see const definitions at top of file for possible values
-	sync.RWMutex        // Protects the above two variables (note: atomic writes are also used somewhat inconsistently)
+	status connectionStatus // see constants in status.go for values
 
 	messageIds // effectively a map from message id to token completor
 
@@ -169,7 +164,6 @@ func NewClient(o *ClientOptions) Client {
 		c.options.protocolVersionExplicit = false
 	}
 	c.persist = c.options.Store
-	c.status = disconnected
 	c.messageIds = messageIds{index: make(map[uint16]tokenCompletor)}
 	c.msgRouter = newRouter()
 	c.msgRouter.setDefaultHandler(c.options.DefaultPublishHandler)
@@ -196,47 +190,27 @@ func (c *client) AddRoute(topic string, callback MessageHandler) {
 // the client is connected or not.
 // connected means that the connection is up now OR it will
 // be established/reestablished automatically when possible
+// Warning: The connection status may change at any time so use this with care!
 func (c *client) IsConnected() bool {
-	c.RLock()
-	defer c.RUnlock()
-	status := atomic.LoadUint32(&c.status)
+	// This will need to change if additional statuses are added
+	s, r := c.status.ConnectionStatusRetry()
 	switch {
-	case status == connected:
+	case s == connected:
 		return true
-	case c.options.AutoReconnect && status > connecting:
+	case c.options.ConnectRetry && s == connecting:
 		return true
-	case c.options.ConnectRetry && status == connecting:
-		return true
+	case c.options.AutoReconnect:
+		return s == reconnecting || (s == disconnecting && r) // r indicates we will reconnect
 	default:
 		return false
 	}
 }
 
 // IsConnectionOpen return a bool signifying whether the client has an active
-// connection to mqtt broker, i.e not in disconnected or reconnect mode
+// connection to mqtt broker, i.e. not in disconnected or reconnect mode
+// Warning: The connection status may change at any time so use this with care!
 func (c *client) IsConnectionOpen() bool {
-	c.RLock()
-	defer c.RUnlock()
-	status := atomic.LoadUint32(&c.status)
-	switch {
-	case status == connected:
-		return true
-	default:
-		return false
-	}
-}
-
-func (c *client) connectionStatus() uint32 {
-	c.RLock()
-	defer c.RUnlock()
-	status := atomic.LoadUint32(&c.status)
-	return status
-}
-
-func (c *client) setConnected(status uint32) {
-	c.Lock()
-	defer c.Unlock()
-	atomic.StoreUint32(&c.status, status)
+	return c.status.ConnectionStatus() == connected
 }
 
 // ErrNotConnected is the error returned from function calls that are
@@ -253,25 +227,31 @@ func (c *client) Connect() Token {
 	t := newToken(packets.Connect).(*ConnectToken)
 	DEBUG.Println(CLI, "Connect()")
 
-	if c.options.ConnectRetry && atomic.LoadUint32(&c.status) != disconnected {
-		// if in any state other than disconnected and ConnectRetry is
-		// enabled then the connection will come up automatically
-		// client can assume connection is up
-		WARN.Println(CLI, "Connect() called but not disconnected")
-		t.returnCode = packets.Accepted
-		t.flowComplete()
+	connectionUp, err := c.status.Connecting()
+	if err != nil {
+		if err == errAlreadyConnectedOrReconnecting && c.options.AutoReconnect {
+			// When reconnection is active we don't consider calls tro Connect to ba an error (mainly for compatability)
+			WARN.Println(CLI, "Connect() called but not disconnected")
+			t.returnCode = packets.Accepted
+			t.flowComplete()
+			return t
+		}
+		ERROR.Println(CLI, err) // CONNECT should never be called unless we are disconnected
+		t.setError(err)
 		return t
 	}
 
 	c.persist.Open()
 	if c.options.ConnectRetry {
-		c.reserveStoredPublishIDs() // Reserve IDs to allow publish before connect complete
+		c.reserveStoredPublishIDs() // Reserve IDs to allow publishing before connect complete
 	}
-	c.setConnected(connecting)
 
 	go func() {
 		if len(c.options.Servers) == 0 {
 			t.setError(fmt.Errorf("no servers defined to connect to"))
+			if err := connectionUp(false); err != nil {
+				ERROR.Println(CLI, err.Error())
+			}
 			return
 		}
 
@@ -285,26 +265,28 @@ func (c *client) Connect() Token {
 				DEBUG.Println(CLI, "Connect failed, sleeping for", int(c.options.ConnectRetryInterval.Seconds()), "seconds and will then retry, error:", err.Error())
 				time.Sleep(c.options.ConnectRetryInterval)
 
-				if atomic.LoadUint32(&c.status) == connecting {
+				if c.status.ConnectionStatus() == connecting { // Possible connection aborted elsewhere
 					goto RETRYCONN
 				}
 			}
 			ERROR.Println(CLI, "Failed to connect to a broker")
-			c.setConnected(disconnected)
 			c.persist.Close()
 			t.returnCode = rc
 			t.setError(err)
+			if err := connectionUp(false); err != nil {
+				ERROR.Println(CLI, err.Error())
+			}
 			return
 		}
-		inboundFromStore := make(chan packets.ControlPacket) // there may be some inbound comms packets in the store that are awaiting processing
-		if c.startCommsWorkers(conn, inboundFromStore) {
+		inboundFromStore := make(chan packets.ControlPacket)           // there may be some inbound comms packets in the store that are awaiting processing
+		if c.startCommsWorkers(conn, connectionUp, inboundFromStore) { // note that this takes care of updating the status (to connected or disconnected)
 			// Take care of any messages in the store
 			if !c.options.CleanSession {
 				c.resume(c.options.ResumeSubs, inboundFromStore)
 			} else {
 				c.persist.Reset()
 			}
-		} else {
+		} else { // Note: With the new status subsystem this should only happen if Disconnect called simultaneously with the above
 			WARN.Println(CLI, "Connect() called but connection established in another goroutine")
 		}
 
@@ -316,7 +298,8 @@ func (c *client) Connect() Token {
 }
 
 // internal function used to reconnect the client when it loses its connection
-func (c *client) reconnect() {
+// The connection status MUST be reconnecting prior to calling this function (via call to status.connectionLost)
+func (c *client) reconnect(connectionUp connCompletedFn) {
 	DEBUG.Println(CLI, "enter reconnect")
 	var (
 		sleep = 1 * time.Second
@@ -341,23 +324,18 @@ func (c *client) reconnect() {
 		if sleep > c.options.MaxReconnectInterval {
 			sleep = c.options.MaxReconnectInterval
 		}
-		// Disconnect may have been called
-		if atomic.LoadUint32(&c.status) == disconnected {
-			break
+
+		if c.status.ConnectionStatus() != reconnecting { // Disconnect may have been called
+			if err := connectionUp(false); err != nil { // Should always return an error
+				ERROR.Println(CLI, err.Error())
+			}
+			DEBUG.Println(CLI, "Client moved to disconnected state while reconnecting, abandoning reconnect")
+			return
 		}
 	}
 
-	// Disconnect() must have been called while we were trying to reconnect.
-	if c.connectionStatus() == disconnected {
-		if conn != nil {
-			conn.Close()
-		}
-		DEBUG.Println(CLI, "Client moved to disconnected state while reconnecting, abandoning reconnect")
-		return
-	}
-
-	inboundFromStore := make(chan packets.ControlPacket) // there may be some inbound comms packets in the store that are awaiting processing
-	if c.startCommsWorkers(conn, inboundFromStore) {
+	inboundFromStore := make(chan packets.ControlPacket)           // there may be some inbound comms packets in the store that are awaiting processing
+	if c.startCommsWorkers(conn, connectionUp, inboundFromStore) { // note that this takes care of updating the status (to connected or disconnected)
 		c.resume(c.options.ResumeSubs, inboundFromStore)
 	}
 	close(inboundFromStore)
@@ -392,6 +370,7 @@ func (c *client) attemptConnection() (net.Conn, byte, bool, error) {
 			DEBUG.Println(CLI, "using custom onConnectAttempt handler...")
 			tlsCfg = c.options.OnConnectAttempt(broker, c.options.TLSConfig)
 		}
+		connDeadline := time.Now().Add(c.options.ConnectTimeout) // Time by which connection must be established
 		dialer := c.options.Dialer
 		if dialer == nil { //
 			WARN.Println(CLI, "dialer was nil, using default")
@@ -411,16 +390,23 @@ func (c *client) attemptConnection() (net.Conn, byte, bool, error) {
 		}
 		DEBUG.Println(CLI, "socket connected to broker")
 
-		// Now we send the perform the MQTT connection handshake
+		// Now we perform the MQTT connection handshake ensuring that it does not exceed the timeout
+		if err := conn.SetDeadline(connDeadline); err != nil {
+			ERROR.Println(CLI, "set deadline for handshake ", err)
+		}
+
+		// Now we perform the MQTT connection handshake
 		rc, sessionPresent, err = connectMQTT(conn, cm, protocolVersion)
 		if rc == packets.Accepted {
+			if err := conn.SetDeadline(time.Time{}); err != nil {
+				ERROR.Println(CLI, "reset deadline following handshake ", err)
+			}
 			break // successfully connected
 		}
 
-		// We may be have to attempt the connection with MQTT 3.1
-		if conn != nil {
-			_ = conn.Close()
-		}
+		// We may have to attempt the connection with MQTT 3.1
+		_ = conn.Close()
+
 		if !c.options.protocolVersionExplicit && protocolVersion == 4 { // try falling back to 3.1?
 			DEBUG.Println(CLI, "Trying reconnect using MQTT 3.1 protocol")
 			protocolVersion = 3
@@ -452,43 +438,59 @@ func (c *client) attemptConnection() (net.Conn, byte, bool, error) {
 // reusing the `client` may lead to panics. If you want to reconnect when the connection drops then use
 // `SetAutoReconnect` and/or `SetConnectRetry`options instead of implementing this yourself.
 func (c *client) Disconnect(quiesce uint) {
-	defer c.disconnect()
+	done := make(chan struct{}) // Simplest way to ensure quiesce is always honoured
+	go func() {
+		defer close(done)
+		disDone, err := c.status.Disconnecting()
+		if err != nil {
+			// Status has been set to disconnecting, but we had to wait for something else to complete
+			WARN.Println(CLI, err.Error())
+			return
+		}
+		defer func() {
+			c.disconnect() // Force disconnection
+			disDone()      // Update status
+		}()
+		DEBUG.Println(CLI, "disconnecting")
+		dm := packets.NewControlPacket(packets.Disconnect).(*packets.DisconnectPacket)
+		dt := newToken(packets.Disconnect)
+		select {
+		case c.oboundP <- &PacketAndToken{p: dm, t: dt}:
+			// wait for work to finish, or quiesce time consumed
+			DEBUG.Println(CLI, "calling WaitTimeout")
+			dt.WaitTimeout(time.Duration(quiesce) * time.Millisecond)
+			DEBUG.Println(CLI, "WaitTimeout done")
+		// Below code causes a potential data race. Following status refactor it should no longer be required
+		// but leaving in as need to check code further.
+		// case <-c.commsStopped:
+		//           WARN.Println("Disconnect packet could not be sent because comms stopped")
+		case <-time.After(time.Duration(quiesce) * time.Millisecond):
+			WARN.Println("Disconnect packet not sent due to timeout")
+		}
+	}()
 
-	status := atomic.LoadUint32(&c.status)
-	c.setConnected(disconnected)
-
-	if status != connected {
-		WARN.Println(CLI, "Disconnect() called but not connected (disconnected/reconnecting)")
-		return
-	}
-
-	DEBUG.Println(CLI, "disconnecting")
-	dm := packets.NewControlPacket(packets.Disconnect).(*packets.DisconnectPacket)
-	dt := newToken(packets.Disconnect)
+	// Return when done or after timeout expires (would like to change but this maintains compatibility)
+	delay := time.NewTimer(time.Duration(quiesce) * time.Millisecond)
 	select {
-	case c.oboundP <- &PacketAndToken{p: dm, t: dt}:
-		// wait for work to finish, or quiesce time consumed
-		DEBUG.Println(CLI, "calling WaitTimeout")
-		dt.WaitTimeout(time.Duration(quiesce) * time.Millisecond)
-		DEBUG.Println(CLI, "WaitTimeout done")
-	// Let's comment this chunk of code until we are able to safely read this variable
-	// without data races.
-	// case <-c.commsStopped:
-	//           WARN.Println("Disconnect packet could not be sent because comms stopped")
-	case <-time.After(time.Duration(quiesce) * time.Millisecond):
-		WARN.Println("Disconnect packet not sent due to timeout")
+	case <-done:
+		if !delay.Stop() {
+			<-delay.C
+		}
+	case <-delay.C:
 	}
 }
 
 // forceDisconnect will end the connection with the mqtt broker immediately (used for tests only)
 func (c *client) forceDisconnect() {
-	if !c.IsConnected() {
-		WARN.Println(CLI, "already disconnected")
+	disDone, err := c.status.Disconnecting()
+	if err != nil {
+		// Possible that we are not actually connected
+		WARN.Println(CLI, err.Error())
 		return
 	}
-	c.setConnected(disconnected)
 	DEBUG.Println(CLI, "forcefully disconnecting")
 	c.disconnect()
+	disDone()
 }
 
 // disconnect cleans up after a final disconnection (user requested so no auto reconnection)
@@ -505,49 +507,79 @@ func (c *client) disconnect() {
 
 // internalConnLost cleanup when connection is lost or an error occurs
 // Note: This function will not block
-func (c *client) internalConnLost(err error) {
+func (c *client) internalConnLost(whyConnLost error) {
 	// It is possible that internalConnLost will be called multiple times simultaneously
 	// (including after sending a DisconnectPacket) as such we only do cleanup etc if the
 	// routines were actually running and are not being disconnected at users request
 	DEBUG.Println(CLI, "internalConnLost called")
-	stopDone := c.stopCommsWorkers()
-	if stopDone != nil { // stopDone will be nil if workers already in the process of stopping or stopped
-		go func() {
-			DEBUG.Println(CLI, "internalConnLost waiting on workers")
-			<-stopDone
-			DEBUG.Println(CLI, "internalConnLost workers stopped")
-			// It is possible that Disconnect was called which led to this error so reconnection depends upon status
-			reconnect := c.options.AutoReconnect && c.connectionStatus() > connecting
-
-			if c.options.CleanSession && !reconnect {
-				c.messageIds.cleanUp() // completes PUB/SUB/UNSUB tokens
-			} else if !c.options.ResumeSubs {
-				c.messageIds.cleanUpSubscribe() // completes SUB/UNSUB tokens
-			}
-			if reconnect {
-				c.setConnected(reconnecting)
-				go c.reconnect()
-			} else {
-				c.setConnected(disconnected)
-			}
-			if c.options.OnConnectionLost != nil {
-				go c.options.OnConnectionLost(c, err)
-			}
-			DEBUG.Println(CLI, "internalConnLost complete")
-		}()
+	disDone, err := c.status.ConnectionLost(c.options.AutoReconnect && c.status.ConnectionStatus() > connecting)
+	if err != nil {
+		if err == errConnLossWhileDisconnecting || err == errAlreadyHandlingConnectionLoss {
+			return // Loss of connection is expected or already being handled
+		}
+		ERROR.Println(CLI, fmt.Sprintf("internalConnLost unexpected status: %s", err.Error()))
+		return
 	}
+
+	// c.stopCommsWorker returns a channel that is closed when the operation completes. This was required prior
+	// to the implementation of proper status management but has been left in place, for now, to minimise change
+	stopDone := c.stopCommsWorkers()
+	// stopDone was required in previous versions because there was no connectionLost status (and there were
+	// issues with status handling). This code has been left in place for the time being just in case the new
+	// status handling contains bugs (refactoring required at some point).
+	if stopDone == nil { // stopDone will be nil if workers already in the process of stopping or stopped
+		ERROR.Println(CLI, "internalConnLost stopDone unexpectedly nil - BUG BUG")
+		// Cannot really do anything other than leave things disconnected
+		if _, err = disDone(false); err != nil { // Safest option - cannot leave status as connectionLost
+			ERROR.Println(CLI, fmt.Sprintf("internalConnLost failed to set status to disconnected (stopDone): %s", err.Error()))
+		}
+		return
+	}
+
+	// It may take a while for the disconnection to complete whatever called us needs to exit cleanly so finnish in goRoutine
+	go func() {
+		DEBUG.Println(CLI, "internalConnLost waiting on workers")
+		<-stopDone
+		DEBUG.Println(CLI, "internalConnLost workers stopped")
+
+		reConnDone, err := disDone(true)
+		if err != nil {
+			ERROR.Println(CLI, "failure whilst reporting completion of disconnect", err)
+		} else if reConnDone == nil { // Should never happen
+			ERROR.Println(CLI, "BUG BUG BUG reconnection function is nil", err)
+		}
+
+		reconnect := err == nil && reConnDone != nil
+
+		if c.options.CleanSession && !reconnect {
+			c.messageIds.cleanUp() // completes PUB/SUB/UNSUB tokens
+		} else if !c.options.ResumeSubs {
+			c.messageIds.cleanUpSubscribe() // completes SUB/UNSUB tokens
+		}
+		if reconnect {
+			go c.reconnect(reConnDone) // Will set connection status to reconnecting
+		}
+		if c.options.OnConnectionLost != nil {
+			go c.options.OnConnectionLost(c, whyConnLost)
+		}
+		DEBUG.Println(CLI, "internalConnLost complete")
+	}()
 }
 
 // startCommsWorkers is called when the connection is up.
-// It starts off all of the routines needed to process incoming and outgoing messages.
-// Returns true if the comms workers were started (i.e. they were not already running)
-func (c *client) startCommsWorkers(conn net.Conn, inboundFromStore <-chan packets.ControlPacket) bool {
+// It starts off the routines needed to process incoming and outgoing messages.
+// Returns true if the comms workers were started (i.e. successful connection)
+// connectionUp(true) will be called once everything is up;  connectionUp(false) will be called on failure
+func (c *client) startCommsWorkers(conn net.Conn, connectionUp connCompletedFn, inboundFromStore <-chan packets.ControlPacket) bool {
 	DEBUG.Println(CLI, "startCommsWorkers called")
 	c.connMu.Lock()
 	defer c.connMu.Unlock()
-	if c.conn != nil {
-		WARN.Println(CLI, "startCommsWorkers called when commsworkers already running")
-		conn.Close() // No use for the new network connection
+	if c.conn != nil { // Should never happen due to new status handling; leaving in for safety for the time being
+		WARN.Println(CLI, "startCommsWorkers called when commsworkers already running BUG BUG")
+		_ = conn.Close() // No use for the new network connection
+		if err := connectionUp(false); err != nil {
+			ERROR.Println(CLI, err.Error())
+		}
 		return false
 	}
 	c.conn = conn // Store the connection
@@ -567,7 +599,17 @@ func (c *client) startCommsWorkers(conn net.Conn, inboundFromStore <-chan packet
 	c.workers.Add(1) // Done will be called when ackOut is closed
 	ackOut := c.msgRouter.matchAndDispatch(incomingPubChan, c.options.Order, c)
 
-	c.setConnected(connected)
+	// The connection is now ready for use (we spin up a few go routines below). It is possible that
+	// Disconnect has been called in the interim...
+	if err := connectionUp(true); err != nil {
+		DEBUG.Println(CLI, err)
+		close(c.stop) // Tidy up anything we have already started
+		close(incomingPubChan)
+		c.workers.Wait()
+		c.conn.Close()
+		c.conn = nil
+		return false
+	}
 	DEBUG.Println(CLI, "client is connected/reconnected")
 	if c.options.OnConnect != nil {
 		go c.options.OnConnect(c)
@@ -660,8 +702,9 @@ func (c *client) startCommsWorkers(conn net.Conn, inboundFromStore <-chan packet
 }
 
 // stopWorkersAndComms - Cleanly shuts down worker go routines (including the comms routines) and waits until everything has stopped
-// Returns nil it workers did not need to be stopped; otherwise returns a channel which will be closed when the stop is complete
+// Returns nil if workers did not need to be stopped; otherwise returns a channel which will be closed when the stop is complete
 // Note: This may block so run as a go routine if calling from any of the comms routines
+// Note2: It should be possible to simplify this now that the new status management code is in place.
 func (c *client) stopCommsWorkers() chan struct{} {
 	DEBUG.Println(CLI, "stopCommsWorkers called")
 	// It is possible that this function will be called multiple times simultaneously due to the way things get shutdown
@@ -710,7 +753,8 @@ func (c *client) Publish(topic string, qos byte, retained bool, payload interfac
 	case !c.IsConnected():
 		token.setError(ErrNotConnected)
 		return token
-	case c.connectionStatus() == reconnecting && qos == 0:
+	case c.status.ConnectionStatus() == reconnecting && qos == 0:
+		// message written to store and will be sent when connection comes up
 		token.flowComplete()
 		return token
 	}
@@ -740,11 +784,13 @@ func (c *client) Publish(topic string, qos byte, retained bool, payload interfac
 		token.messageID = mID
 	}
 	persistOutbound(c.persist, pub)
-	switch c.connectionStatus() {
+	switch c.status.ConnectionStatus() {
 	case connecting:
 		DEBUG.Println(CLI, "storing publish message (connecting), topic:", topic)
 	case reconnecting:
 		DEBUG.Println(CLI, "storing publish message (reconnecting), topic:", topic)
+	case disconnecting:
+		DEBUG.Println(CLI, "storing publish message (disconnecting), topic:", topic)
 	default:
 		DEBUG.Println(CLI, "sending publish message, topic:", topic)
 		publishWaitTimeout := c.options.WriteTimeout
@@ -777,11 +823,11 @@ func (c *client) Subscribe(topic string, qos byte, callback MessageHandler) Toke
 	if !c.IsConnectionOpen() {
 		switch {
 		case !c.options.ResumeSubs:
-			// if not connected and resumesubs not set this sub will be thrown away
+			// if not connected and resumeSubs not set this sub will be thrown away
 			token.setError(fmt.Errorf("not currently connected and ResumeSubs not set"))
 			return token
-		case c.options.CleanSession && c.connectionStatus() == reconnecting:
-			// if reconnecting and cleansession is true this sub will be thrown away
+		case c.options.CleanSession && c.status.ConnectionStatus() == reconnecting:
+			// if reconnecting and cleanSession is true this sub will be thrown away
 			token.setError(fmt.Errorf("reconnecting state and cleansession is true"))
 			return token
 		}
@@ -822,11 +868,13 @@ func (c *client) Subscribe(topic string, qos byte, callback MessageHandler) Toke
 	if c.options.ResumeSubs { // Only persist if we need this to resume subs after a disconnection
 		persistOutbound(c.persist, sub)
 	}
-	switch c.connectionStatus() {
+	switch c.status.ConnectionStatus() {
 	case connecting:
 		DEBUG.Println(CLI, "storing subscribe message (connecting), topic:", topic)
 	case reconnecting:
 		DEBUG.Println(CLI, "storing subscribe message (reconnecting), topic:", topic)
+	case disconnecting:
+		DEBUG.Println(CLI, "storing subscribe message (disconnecting), topic:", topic)
 	default:
 		DEBUG.Println(CLI, "sending subscribe message, topic:", topic)
 		subscribeWaitTimeout := c.options.WriteTimeout
@@ -864,8 +912,8 @@ func (c *client) SubscribeMultiple(filters map[string]byte, callback MessageHand
 			// if not connected and resumesubs not set this sub will be thrown away
 			token.setError(fmt.Errorf("not currently connected and ResumeSubs not set"))
 			return token
-		case c.options.CleanSession && c.connectionStatus() == reconnecting:
-			// if reconnecting and cleansession is true this sub will be thrown away
+		case c.options.CleanSession && c.status.ConnectionStatus() == reconnecting:
+			// if reconnecting and cleanSession is true this sub will be thrown away
 			token.setError(fmt.Errorf("reconnecting state and cleansession is true"))
 			return token
 		}
@@ -896,11 +944,13 @@ func (c *client) SubscribeMultiple(filters map[string]byte, callback MessageHand
 	if c.options.ResumeSubs { // Only persist if we need this to resume subs after a disconnection
 		persistOutbound(c.persist, sub)
 	}
-	switch c.connectionStatus() {
+	switch c.status.ConnectionStatus() {
 	case connecting:
 		DEBUG.Println(CLI, "storing subscribe message (connecting), topics:", sub.Topics)
 	case reconnecting:
 		DEBUG.Println(CLI, "storing subscribe message (reconnecting), topics:", sub.Topics)
+	case disconnecting:
+		DEBUG.Println(CLI, "storing subscribe message (disconnecting), topics:", sub.Topics)
 	default:
 		DEBUG.Println(CLI, "sending subscribe message, topics:", sub.Topics)
 		subscribeWaitTimeout := c.options.WriteTimeout
@@ -1050,7 +1100,7 @@ func (c *client) resume(subscription bool, ibound chan packets.ControlPacket) {
 				}
 				releaseSemaphore(token) // If limiting simultaneous messages then we need to know when message is acknowledged
 			default:
-				ERROR.Println(STR, "invalid message type in store (discarded)")
+				ERROR.Println(STR, fmt.Sprintf("invalid message type (inbound - %T) in store (discarded)", packet))
 				c.persist.Del(key)
 			}
 		} else {
@@ -1064,7 +1114,7 @@ func (c *client) resume(subscription bool, ibound chan packets.ControlPacket) {
 					return
 				}
 			default:
-				ERROR.Println(STR, "invalid message type in store (discarded)")
+				ERROR.Println(STR, fmt.Sprintf("invalid message type (%T) in store (discarded)", packet))
 				c.persist.Del(key)
 			}
 		}
@@ -1085,11 +1135,11 @@ func (c *client) Unsubscribe(topics ...string) Token {
 	if !c.IsConnectionOpen() {
 		switch {
 		case !c.options.ResumeSubs:
-			// if not connected and resumesubs not set this unsub will be thrown away
+			// if not connected and resumeSubs not set this unsub will be thrown away
 			token.setError(fmt.Errorf("not currently connected and ResumeSubs not set"))
 			return token
-		case c.options.CleanSession && c.connectionStatus() == reconnecting:
-			// if reconnecting and cleansession is true this unsub will be thrown away
+		case c.options.CleanSession && c.status.ConnectionStatus() == reconnecting:
+			// if reconnecting and cleanSession is true this unsub will be thrown away
 			token.setError(fmt.Errorf("reconnecting state and cleansession is true"))
 			return token
 		}
@@ -1112,10 +1162,12 @@ func (c *client) Unsubscribe(topics ...string) Token {
 		persistOutbound(c.persist, unsub)
 	}
 
-	switch c.connectionStatus() {
+	switch c.status.ConnectionStatus() {
 	case connecting:
 		DEBUG.Println(CLI, "storing unsubscribe message (connecting), topics:", topics)
 	case reconnecting:
+		DEBUG.Println(CLI, "storing unsubscribe message (reconnecting), topics:", topics)
+	case disconnecting:
 		DEBUG.Println(CLI, "storing unsubscribe message (reconnecting), topics:", topics)
 	default:
 		DEBUG.Println(CLI, "sending unsubscribe message, topics:", topics)

--- a/vendor/github.com/eclipse/paho.mqtt.golang/net.go
+++ b/vendor/github.com/eclipse/paho.mqtt.golang/net.go
@@ -150,7 +150,7 @@ type incomingComms struct {
 
 // startIncomingComms initiates incoming communications; this includes starting a goroutine to process incoming
 // messages.
-// Accepts a channel of inbound messages from the store (persisted messages); note this must be closed as soon as the
+// Accepts a channel of inbound messages from the store (persisted messages); note this must be closed as soon as
 // everything in the store has been sent.
 // Returns a channel that will be passed any received packets; this will be closed on a network error (and inboundFromStore closed)
 func startIncomingComms(conn io.Reader,
@@ -332,7 +332,7 @@ func startOutgoingComms(conn net.Conn,
 					DEBUG.Println(NET, "outbound wrote disconnect, closing connection")
 					// As per the MQTT spec "After sending a DISCONNECT Packet the Client MUST close the Network Connection"
 					// Closing the connection will cause the goroutines to end in sequence (starting with incoming comms)
-					conn.Close()
+					_ = conn.Close()
 				}
 			case msg, ok := <-oboundFromIncoming: // message triggered by an inbound message (PubrecPacket or PubrelPacket)
 				if !ok {
@@ -370,9 +370,10 @@ type commsFns interface {
 // startComms initiates goroutines that handles communications over the network connection
 // Messages will be stored (via commsFns) and deleted from the store as necessary
 // It returns two channels:
-//  packets.PublishPacket - Will receive publish packets received over the network.
-//  Closed when incoming comms routines exit (on shutdown or if network link closed)
-//  error - Any errors will be sent on this channel. The channel is closed when all comms routines have shut down
+//
+//	packets.PublishPacket - Will receive publish packets received over the network.
+//	Closed when incoming comms routines exit (on shutdown or if network link closed)
+//	error - Any errors will be sent on this channel. The channel is closed when all comms routines have shut down
 //
 // Note: The comms routines monitoring oboundp and obound will not shutdown until those channels are both closed. Any messages received between the
 // connection being closed and those channels being closed will generate errors (and nothing will be sent). That way the chance of a deadlock is

--- a/vendor/github.com/eclipse/paho.mqtt.golang/options.go
+++ b/vendor/github.com/eclipse/paho.mqtt.golang/options.go
@@ -104,6 +104,7 @@ type ClientOptions struct {
 	MaxResumePubInFlight    int // // 0 = no limit; otherwise this is the maximum simultaneous messages sent while resuming
 	Dialer                  *net.Dialer
 	CustomOpenConnectionFn  OpenConnectionFunc
+	AutoAckDisabled         bool
 }
 
 // NewClientOptions will create a new ClientClientOptions type with some
@@ -147,6 +148,7 @@ func NewClientOptions() *ClientOptions {
 		WebsocketOptions:        &WebsocketOptions{},
 		Dialer:                  &net.Dialer{Timeout: 30 * time.Second},
 		CustomOpenConnectionFn:  nil,
+		AutoAckDisabled:         false,
 	}
 	return o
 }
@@ -444,5 +446,12 @@ func (o *ClientOptions) SetCustomOpenConnectionFn(customOpenConnectionFn OpenCon
 	if customOpenConnectionFn != nil {
 		o.CustomOpenConnectionFn = customOpenConnectionFn
 	}
+	return o
+}
+
+// SetAutoAckDisabled enables or disables the Automated Acking of Messages received by the handler.
+//	By default it is set to false. Setting it to true will disable the auto-ack globally.
+func (o *ClientOptions) SetAutoAckDisabled(autoAckDisabled bool) *ClientOptions {
+	o.AutoAckDisabled = autoAckDisabled
 	return o
 }

--- a/vendor/github.com/eclipse/paho.mqtt.golang/ping.go
+++ b/vendor/github.com/eclipse/paho.mqtt.golang/ping.go
@@ -58,8 +58,8 @@ func keepalive(c *client, conn io.Writer) {
 				if atomic.LoadInt32(&c.pingOutstanding) == 0 {
 					DEBUG.Println(PNG, "keepalive sending ping")
 					ping := packets.NewControlPacket(packets.Pingreq).(*packets.PingreqPacket)
-					// We don't want to wait behind large messages being sent, the Write call
-					// will block until it it able to send the packet.
+					// We don't want to wait behind large messages being sent, the `Write` call
+					// will block until it is able to send the packet.
 					atomic.StoreInt32(&c.pingOutstanding, 1)
 					if err := ping.Write(conn); err != nil {
 						ERROR.Println(PNG, err)

--- a/vendor/github.com/eclipse/paho.mqtt.golang/router.go
+++ b/vendor/github.com/eclipse/paho.mqtt.golang/router.go
@@ -186,7 +186,9 @@ func (r *router) matchAndDispatch(messages <-chan *packets.PublishPacket, order 
 						wg.Add(1)
 						go func() {
 							hd(client, m)
-							m.Ack()
+							if !client.options.AutoAckDisabled {
+								m.Ack()
+							}
 							wg.Done()
 						}()
 					}
@@ -201,7 +203,9 @@ func (r *router) matchAndDispatch(messages <-chan *packets.PublishPacket, order 
 						wg.Add(1)
 						go func() {
 							r.defaultHandler(client, m)
-							m.Ack()
+							if !client.options.AutoAckDisabled {
+								m.Ack()
+							}
 							wg.Done()
 						}()
 					}
@@ -212,7 +216,9 @@ func (r *router) matchAndDispatch(messages <-chan *packets.PublishPacket, order 
 			r.RUnlock()
 			for _, handler := range handlers {
 				handler(client, m)
-				m.Ack()
+				if !client.options.AutoAckDisabled {
+					m.Ack()
+				}
 			}
 			// DEBUG.Println(ROU, "matchAndDispatch handled message")
 		}

--- a/vendor/github.com/eclipse/paho.mqtt.golang/status.go
+++ b/vendor/github.com/eclipse/paho.mqtt.golang/status.go
@@ -1,0 +1,296 @@
+/*
+ * Copyright (c) 2021 IBM Corp and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    https://www.eclipse.org/legal/epl-2.0/
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Seth Hoenig
+ *    Allan Stockdill-Mander
+ *    Mike Robertson
+ *    Matt Brittan
+ */
+
+package mqtt
+
+import (
+	"errors"
+	"sync"
+)
+
+// Status - Manage the connection status
+
+// Multiple go routines will want to access/set this. Previously status was implemented as a `uint32` and updated
+// with a mixture of atomic functions and a mutex (leading to some deadlock type issues that were very hard to debug).
+
+// In this new implementation `connectionStatus` takes over managing the state and provides functions that allow the
+// client to request a move to a particular state (it may reject these requests!). In some cases the 'state' is
+// transitory, for example `connecting`, in those cases a function will be returned that allows the client to move
+// to a more static state (`disconnected` or `connected`).
+
+// This "belts-and-braces" may be a little over the top but issues with the status have caused a number of difficult
+// to trace bugs in the past and the likelihood that introducing a new system would introduce bugs seemed high!
+// I have written this in a way that should make it very difficult to misuse it (but it does make things a little
+// complex with functions returning functions that return functions!).
+
+type status uint32
+
+const (
+	disconnected  status = iota // default (nil) status is disconnected
+	disconnecting               // Transitioning from one of the below states back to disconnected
+	connecting
+	reconnecting
+	connected
+)
+
+// String simplify output of statuses
+func (s status) String() string {
+	switch s {
+	case disconnected:
+		return "disconnected"
+	case disconnecting:
+		return "disconnecting"
+	case connecting:
+		return "connecting"
+	case reconnecting:
+		return "reconnecting"
+	case connected:
+		return "connected"
+	default:
+		return "invalid"
+	}
+}
+
+type connCompletedFn func(success bool) error
+type disconnectCompletedFn func()
+type connectionLostHandledFn func(bool) (connCompletedFn, error)
+
+/* State transitions
+
+static states are `disconnected` and `connected`. For all other states a process will hold a function that will move
+the state to one of those. That function effectively owns the state and any other changes must not proceed until it
+completes. One exception to that is that the state can always be moved to `disconnecting` which provides a signal that
+transitions to `connected` will be rejected (this is required because a Disconnect can be requested while in the
+Connecting state).
+
+# Basic Operations
+
+The standard workflows are:
+
+disconnected -> `Connecting()` -> connecting -> `connCompletedFn(true)` -> connected
+connected -> `Disconnecting()` -> disconnecting -> `disconnectCompletedFn()` -> disconnected
+connected -> `ConnectionLost(false)` -> disconnecting -> `connectionLostHandledFn(true/false)` -> disconnected
+connected -> `ConnectionLost(true)` -> disconnecting -> `connectionLostHandledFn(true)` -> connected
+
+Unfortunately the above workflows are complicated by the fact that `Disconnecting()` or `ConnectionLost()` may,
+potentially, be called at any time (i.e. whilst in the middle of transitioning between states). If this happens:
+
+* The state will be set to disconnecting (which will prevent any request to move the status to connected)
+* The call to `Disconnecting()`/`ConnectionLost()` will block until the previously active call completes and then
+  handle the disconnection.
+
+Reading the tests (unit_status_test.go) might help understand these rules.
+*/
+
+var (
+	errAbortConnection                = errors.New("disconnect called whist connection attempt in progress")
+	errAlreadyConnectedOrReconnecting = errors.New("status is already connected or reconnecting")
+	errStatusMustBeDisconnected       = errors.New("status can only transition to connecting from disconnected")
+	errAlreadyDisconnected            = errors.New("status is already disconnected")
+	errDisconnectionRequested         = errors.New("disconnection was requested whilst the action was in progress")
+	errDisconnectionInProgress        = errors.New("disconnection already in progress")
+	errAlreadyHandlingConnectionLoss  = errors.New("status is already Connection Lost")
+	errConnLossWhileDisconnecting     = errors.New("connection status is disconnecting so loss of connection is expected")
+)
+
+// connectionStatus encapsulates, and protects, the connection status.
+type connectionStatus struct {
+	sync.RWMutex  // Protects the variables below
+	status        status
+	willReconnect bool // only used when status == disconnecting. Indicates that an attempt will be made to reconnect (allows us to abort that)
+
+	// Some statuses are transitional (e.g. connecting, connectionLost, reconnecting, disconnecting), that is, whatever
+	// process moves us into that status will move us out of it when an action is complete. Sometimes other users
+	// will need to know when the action is complete (e.g. the user calls `Disconnect()` whilst the status is
+	// `connecting`). `actionCompleted` will be set whenever we move into one of the above statues and the channel
+	// returned to anything else requesting a status change. The channel will be closed when the operation is complete.
+	actionCompleted chan struct{} // Only valid whilst status is Connecting or Reconnecting; will be closed when connection completed (success or failure)
+}
+
+// ConnectionStatus returns the connection status.
+// WARNING: the status may change at any time so users should not assume they are the only goroutine touching this
+func (c *connectionStatus) ConnectionStatus() status {
+	c.RLock()
+	defer c.RUnlock()
+	return c.status
+}
+
+// ConnectionStatusRetry returns the connection status and retry flag (indicates that we expect to reconnect).
+// WARNING: the status may change at any time so users should not assume they are the only goroutine touching this
+func (c *connectionStatus) ConnectionStatusRetry() (status, bool) {
+	c.RLock()
+	defer c.RUnlock()
+	return c.status, c.willReconnect
+}
+
+// Connecting - Changes the status to connecting if that is a permitted operation
+// Will do nothing unless the current status is disconnected
+// Returns a function that MUST be called when the operation is complete (pass in true if successful)
+func (c *connectionStatus) Connecting() (connCompletedFn, error) {
+	c.Lock()
+	defer c.Unlock()
+	// Calling Connect when already connecting (or if reconnecting) may not always be considered an error
+	if c.status == connected || c.status == reconnecting {
+		return nil, errAlreadyConnectedOrReconnecting
+	}
+	if c.status != disconnected {
+		return nil, errStatusMustBeDisconnected
+	}
+	c.status = connecting
+	c.actionCompleted = make(chan struct{})
+	return c.connected, nil
+}
+
+// connected is an internal function (it is returned by functions that set the status to connecting or reconnecting,
+// calling it completes the operation). `success` is used to indicate whether the operation was successfully completed.
+func (c *connectionStatus) connected(success bool) error {
+	c.Lock()
+	defer func() {
+		close(c.actionCompleted) // Alert anything waiting on the connection process to complete
+		c.actionCompleted = nil  // Be tidy
+		c.Unlock()
+	}()
+
+	// Status may have moved to disconnecting in the interim (i.e. at users request)
+	if c.status == disconnecting {
+		return errAbortConnection
+	}
+	if success {
+		c.status = connected
+	} else {
+		c.status = disconnected
+	}
+	return nil
+}
+
+// Disconnecting - should be called when beginning the disconnection process (cleanup etc.).
+// Can be called from ANY status and the end result will always be a status of disconnected
+// Note that if a connection/reconnection attempt is in progress this function will set the status to `disconnecting`
+// then block until the connection process completes (or aborts).
+// Returns a function that MUST be called when the operation is complete (assumed to always be successful!)
+func (c *connectionStatus) Disconnecting() (disconnectCompletedFn, error) {
+	c.Lock()
+	if c.status == disconnected {
+		c.Unlock()
+		return nil, errAlreadyDisconnected // May not always be treated as an error
+	}
+	if c.status == disconnecting { // Need to wait for existing process to complete
+		c.willReconnect = false // Ensure that the existing disconnect process will not reconnect
+		disConnectDone := c.actionCompleted
+		c.Unlock()
+		<-disConnectDone                   // Wait for existing operation to complete
+		return nil, errAlreadyDisconnected // Well we are now!
+	}
+
+	prevStatus := c.status
+	c.status = disconnecting
+
+	// We may need to wait for connection/reconnection process to complete (they should regularly check the status)
+	if prevStatus == connecting || prevStatus == reconnecting {
+		connectDone := c.actionCompleted
+		c.Unlock() // Safe because the only way to leave the disconnecting status is via this function
+		<-connectDone
+
+		if prevStatus == reconnecting && !c.willReconnect {
+			return nil, errAlreadyDisconnected // Following connectionLost process we will be disconnected
+		}
+		c.Lock()
+	}
+	c.actionCompleted = make(chan struct{})
+	c.Unlock()
+	return c.disconnectionCompleted, nil
+}
+
+// disconnectionCompleted is an internal function (it is returned by functions that set the status to disconnecting)
+func (c *connectionStatus) disconnectionCompleted() {
+	c.Lock()
+	defer c.Unlock()
+	c.status = disconnected
+	close(c.actionCompleted) // Alert anything waiting on the connection process to complete
+	c.actionCompleted = nil
+}
+
+// ConnectionLost - should be called when the connection is lost.
+// This really only differs from Disconnecting in that we may transition into a reconnection (but that could be
+// cancelled something else calls Disconnecting in the meantime).
+// The returned function should be called when cleanup is completed. It will return a function to be called when
+// reconnect completes (or nil if no reconnect requested/disconnect called in the interim).
+// Note: This function may block if a connection is in progress (the move to connected will be rejected)
+func (c *connectionStatus) ConnectionLost(willReconnect bool) (connectionLostHandledFn, error) {
+	c.Lock()
+	defer c.Unlock()
+	if c.status == disconnected {
+		return nil, errAlreadyDisconnected
+	}
+	if c.status == disconnecting { // its expected that connection lost will be called during the disconnection process
+		return nil, errDisconnectionInProgress
+	}
+
+	c.willReconnect = willReconnect
+	prevStatus := c.status
+	c.status = disconnecting
+
+	// There is a slight possibility that a connection attempt is in progress (connection up and goroutines started but
+	// status not yet changed). By changing the status we ensure that process will exit cleanly
+	if prevStatus == connecting || prevStatus == reconnecting {
+		connectDone := c.actionCompleted
+		c.Unlock() // Safe because the only way to leave the disconnecting status is via this function
+		<-connectDone
+		c.Lock()
+		if !willReconnect {
+			// In this case the connection will always be aborted so there is nothing more for us to do
+			return nil, errAlreadyDisconnected
+		}
+	}
+	c.actionCompleted = make(chan struct{})
+
+	return c.getConnectionLostHandler(willReconnect), nil
+}
+
+// getConnectionLostHandler is an internal function. It returns the function to be returned by ConnectionLost
+func (c *connectionStatus) getConnectionLostHandler(reconnectRequested bool) connectionLostHandledFn {
+	return func(proceed bool) (connCompletedFn, error) {
+		// Note that connCompletedFn will only be provided if both reconnectRequested and proceed are true
+		c.Lock()
+		defer c.Unlock()
+
+		// `Disconnecting()` may have been called while the disconnection was being processed (this makes it permanent!)
+		if !c.willReconnect || !proceed {
+			c.status = disconnected
+			close(c.actionCompleted) // Alert anything waiting on the connection process to complete
+			c.actionCompleted = nil
+			if !reconnectRequested || !proceed {
+				return nil, nil
+			}
+			return nil, errDisconnectionRequested
+		}
+
+		c.status = reconnecting
+		return c.connected, nil // Note that c.actionCompleted is still live and will be closed in connected
+	}
+}
+
+// forceConnectionStatus - forces the connection status to the specified value.
+// This should only be used when there is no alternative (i.e. only in tests and to recover from situations that
+// are unexpected)
+func (c *connectionStatus) forceConnectionStatus(s status) {
+	c.Lock()
+	defer c.Unlock()
+	c.status = s
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -31,7 +31,7 @@ github.com/davecgh/go-spew/spew
 # github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f
 ## explicit
 github.com/dgryski/go-rendezvous
-# github.com/eclipse/paho.mqtt.golang v1.4.1
+# github.com/eclipse/paho.mqtt.golang v1.4.2
 ## explicit; go 1.14
 github.com/eclipse/paho.mqtt.golang
 github.com/eclipse/paho.mqtt.golang/packets
@@ -174,7 +174,7 @@ golang.org/x/text/transform
 golang.org/x/text/unicode/bidi
 golang.org/x/text/unicode/norm
 golang.org/x/text/width
-# google.golang.org/genproto v0.0.0-20221024153911-1573dae28c9c
+# google.golang.org/genproto v0.0.0-20221025140454-527a21cfbd71
 ## explicit; go 1.19
 google.golang.org/genproto/googleapis/api/annotations
 google.golang.org/genproto/googleapis/api/httpbody


### PR DESCRIPTION
- Update `pkg/queue`, and atlas-mqtt-ingestor and atlas-lora-ingestor services.
- Sync `vendor/` for updated dependencies.
- All test variations pass.