### PR TITLE
Make API host configurable to silence potential firewall prompts

### DIFF
--- a/build/deploy/atlas/docker-compose.yml
+++ b/build/deploy/atlas/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   atlas-api:
-    image: ghcr.io/thingspect/atlas:02223ef8
+    image: ghcr.io/thingspect/atlas:b6ec4477
     command: atlas-api
     restart: on-failure
     ports:
@@ -20,7 +20,7 @@ services:
       - API_LORA_DEV_PROF_ID=00000000-0000-0000-0000-000000000000
 
   atlas-mqtt-ingestor:
-    image: ghcr.io/thingspect/atlas:02223ef8
+    image: ghcr.io/thingspect/atlas:b6ec4477
     command: atlas-mqtt-ingestor
     restart: on-failure
     depends_on:
@@ -32,7 +32,7 @@ services:
       - MQTT_INGEST_NSQ_PUB_ADDR=nsqd:4150
 
   atlas-lora-ingestor:
-    image: ghcr.io/thingspect/atlas:02223ef8
+    image: ghcr.io/thingspect/atlas:b6ec4477
     command: atlas-lora-ingestor
     restart: on-failure
     depends_on:
@@ -45,7 +45,7 @@ services:
       - LORA_INGEST_NSQ_PUB_ADDR=nsqd:4150
 
   atlas-decoder:
-    image: ghcr.io/thingspect/atlas:02223ef8
+    image: ghcr.io/thingspect/atlas:b6ec4477
     command: atlas-decoder
     restart: on-failure
     depends_on:
@@ -57,7 +57,7 @@ services:
       - DECODER_NSQ_LOOKUP_ADDRS=nsqlookupd:4161
 
   atlas-validator:
-    image: ghcr.io/thingspect/atlas:02223ef8
+    image: ghcr.io/thingspect/atlas:b6ec4477
     command: atlas-validator
     restart: on-failure
     depends_on:
@@ -70,7 +70,7 @@ services:
       - VALIDATOR_NSQ_LOOKUP_ADDRS=nsqlookupd:4161
 
   atlas-accumulator:
-    image: ghcr.io/thingspect/atlas:02223ef8
+    image: ghcr.io/thingspect/atlas:b6ec4477
     command: atlas-accumulator
     restart: on-failure
     environment:
@@ -80,7 +80,7 @@ services:
       - ACCUMULATOR_NSQ_LOOKUP_ADDRS=nsqlookupd:4161
 
   atlas-eventer:
-    image: ghcr.io/thingspect/atlas:02223ef8
+    image: ghcr.io/thingspect/atlas:b6ec4477
     command: atlas-eventer
     restart: on-failure
     depends_on:
@@ -92,7 +92,7 @@ services:
       - EVENTER_NSQ_LOOKUP_ADDRS=nsqlookupd:4161
 
   atlas-alerter:
-    image: ghcr.io/thingspect/atlas:02223ef8
+    image: ghcr.io/thingspect/atlas:b6ec4477
     command: atlas-alerter
     restart: on-failure
     environment:

--- a/internal/atlas-api/api/api.go
+++ b/internal/atlas-api/api/api.go
@@ -53,6 +53,7 @@ const errPWTLength consterr.Error = "pwt key must be 32 bytes"
 
 // API holds references to the gRPC and HTTP servers.
 type API struct {
+	apiHost    string
 	grpcSrv    *grpc.Server
 	httpSrv    *http.Server
 	httpCancel context.CancelFunc
@@ -213,9 +214,10 @@ func New(cfg *config.Config) (*API, error) {
 	mux.Handle("/", http.FileServer(http.Dir("web")))
 
 	return &API{
+		apiHost: cfg.APIHost,
 		grpcSrv: srv,
 		httpSrv: &http.Server{
-			Addr:              httpPort,
+			Addr:              cfg.APIHost + httpPort,
 			Handler:           gziphandler.GzipHandler(mux),
 			ReadHeaderTimeout: 60 * time.Second,
 		},
@@ -225,15 +227,14 @@ func New(cfg *config.Config) (*API, error) {
 
 // Serve starts the listener.
 func (api *API) Serve() {
-	//#nosec G102 // service should listen on all interfaces
-	lis, err := net.Listen("tcp", GRPCPort)
+	lis, err := net.Listen("tcp", api.apiHost+GRPCPort)
 	if err != nil {
 		alog.Fatalf("Serve net.Listen: %v", err)
 	}
 
 	// Serve gRPC.
 	go func() {
-		alog.Infof("Listening on %v", GRPCPort)
+		alog.Infof("Listening on %v", api.apiHost+GRPCPort)
 		if err := api.grpcSrv.Serve(lis); err != nil {
 			alog.Fatalf("Serve api.grpcSrv.Serve: %v", err)
 		}
@@ -241,7 +242,7 @@ func (api *API) Serve() {
 
 	// Serve gRPC-gateway.
 	go func() {
-		alog.Infof("Listening on %v", httpPort)
+		alog.Infof("Listening on %v", api.httpSrv.Addr)
 		if err := api.httpSrv.ListenAndServe(); err != nil {
 			alog.Fatalf("Serve api.httpSrv.ListenAndServe: %v", err)
 		}

--- a/internal/atlas-api/config/config.go
+++ b/internal/atlas-api/config/config.go
@@ -14,8 +14,6 @@ type Config struct {
 	PgURI     string
 	RedisHost string
 
-	PWTKey []byte
-
 	NSQPubAddr  string
 	NSQPubTopic string
 
@@ -24,6 +22,9 @@ type Config struct {
 	LoRaTenantID  string
 	LoRaAppID     string
 	LoRaDevProfID string
+
+	PWTKey  []byte
+	APIHost string
 }
 
 // New instantiates a service Config, parses the environment, and returns it.
@@ -36,8 +37,6 @@ func New() *Config {
 			"postgres://postgres:postgres@127.0.0.1/atlas_test"),
 		RedisHost: config.String(pref+"REDIS_HOST", "127.0.0.1"),
 
-		PWTKey: config.ByteSlice(pref + "PWT_KEY"),
-
 		NSQPubAddr:  config.String(pref+"NSQ_PUB_ADDR", "127.0.0.1:4150"),
 		NSQPubTopic: config.String(pref+"NSQ_PUB_TOPIC", "ValidatorIn"),
 
@@ -46,5 +45,8 @@ func New() *Config {
 		LoRaTenantID:  config.String(pref+"LORA_TENANT_ID", ""),
 		LoRaAppID:     config.String(pref+"LORA_APP_ID", ""),
 		LoRaDevProfID: config.String(pref+"LORA_DEV_PROF_ID", ""),
+
+		PWTKey:  config.ByteSlice(pref + "PWT_KEY"),
+		APIHost: config.String(pref+"API_HOST", ""),
 	}
 }

--- a/internal/atlas-api/test/main_test.go
+++ b/internal/atlas-api/test/main_test.go
@@ -68,12 +68,13 @@ func TestMain(m *testing.M) {
 	cfg.PgURI = testConfig.PgURI
 	cfg.RedisHost = testConfig.RedisHost
 
-	cfg.PWTKey = key
-
 	cfg.NSQPubAddr = testConfig.NSQPubAddr
 	cfg.NSQPubTopic += "-test-" + random.String(10)
 	globalPubTopic = cfg.NSQPubTopic
 	log.Printf("TestMain cfg.NSQPubTopic: %v", cfg.NSQPubTopic)
+
+	cfg.PWTKey = key
+	cfg.APIHost = testConfig.APIHost
 
 	// Set up API.
 	a, err := iapi.New(cfg)

--- a/pkg/test/config/config.go
+++ b/pkg/test/config/config.go
@@ -17,6 +17,8 @@ type Config struct {
 	MQTTAddr string
 	MQTTUser string
 	MQTTPass string
+
+	APIHost string
 }
 
 // New instantiates a test Config, parses the environment, and returns it.
@@ -33,5 +35,7 @@ func New() *Config {
 		MQTTAddr: config.String(pref+"MQTT_ADDR", "tcp://127.0.0.1:1883"),
 		MQTTUser: config.String(pref+"MQTT_USER", "atlas_test"),
 		MQTTPass: config.String(pref+"MQTT_PASS", "notasecurepassword"),
+
+		APIHost: config.String(pref+"API_HOST", "127.0.0.1"),
 	}
 }


### PR DESCRIPTION
- Update config, api, integration tests, and `pkg/test/config`.
- All test variations pass.