### PR TITLE
Enable device DAO caching in decoder and validator services

### DIFF
--- a/build/deploy/atlas/docker-compose.yml
+++ b/build/deploy/atlas/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   atlas-api:
-    image: ghcr.io/thingspect/atlas:9e77c656
+    image: ghcr.io/thingspect/atlas:2f9ab344
     command: atlas-api
     restart: on-failure
     ports:
@@ -22,7 +22,7 @@ services:
       - API_LORA_DEV_PROF_ID=00000000-0000-0000-0000-000000000000
 
   atlas-mqtt-ingestor:
-    image: ghcr.io/thingspect/atlas:9e77c656
+    image: ghcr.io/thingspect/atlas:2f9ab344
     command: atlas-mqtt-ingestor
     restart: on-failure
     depends_on:
@@ -34,7 +34,7 @@ services:
       - MQTT_INGEST_NSQ_PUB_ADDR=nsqd:4150
 
   atlas-lora-ingestor:
-    image: ghcr.io/thingspect/atlas:9e77c656
+    image: ghcr.io/thingspect/atlas:2f9ab344
     command: atlas-lora-ingestor
     restart: on-failure
     depends_on:
@@ -47,7 +47,7 @@ services:
       - LORA_INGEST_NSQ_PUB_ADDR=nsqd:4150
 
   atlas-decoder:
-    image: ghcr.io/thingspect/atlas:9e77c656
+    image: ghcr.io/thingspect/atlas:2f9ab344
     command: atlas-decoder
     restart: on-failure
     depends_on:
@@ -55,11 +55,12 @@ services:
     environment:
       - DECODER_STATSD_ADDR=dogstatsd:8125
       - DECODER_PG_URI=postgres://postgres:notasecurepassword@postgres/atlas
+      - DECODER_REDIS_HOST=redis
       - DECODER_NSQ_PUB_ADDR=nsqd:4150
       - DECODER_NSQ_LOOKUP_ADDRS=nsqlookupd:4161
 
   atlas-validator:
-    image: ghcr.io/thingspect/atlas:9e77c656
+    image: ghcr.io/thingspect/atlas:2f9ab344
     command: atlas-validator
     restart: on-failure
     depends_on:
@@ -68,11 +69,12 @@ services:
     environment:
       - VALIDATOR_STATSD_ADDR=dogstatsd:8125
       - VALIDATOR_PG_URI=postgres://postgres:notasecurepassword@postgres/atlas
+      - VALIDATOR_REDIS_HOST=redis
       - VALIDATOR_NSQ_PUB_ADDR=nsqd:4150
       - VALIDATOR_NSQ_LOOKUP_ADDRS=nsqlookupd:4161
 
   atlas-accumulator:
-    image: ghcr.io/thingspect/atlas:9e77c656
+    image: ghcr.io/thingspect/atlas:2f9ab344
     command: atlas-accumulator
     restart: on-failure
     environment:
@@ -82,7 +84,7 @@ services:
       - ACCUMULATOR_NSQ_LOOKUP_ADDRS=nsqlookupd:4161
 
   atlas-eventer:
-    image: ghcr.io/thingspect/atlas:9e77c656
+    image: ghcr.io/thingspect/atlas:2f9ab344
     command: atlas-eventer
     restart: on-failure
     depends_on:
@@ -94,7 +96,7 @@ services:
       - EVENTER_NSQ_LOOKUP_ADDRS=nsqlookupd:4161
 
   atlas-alerter:
-    image: ghcr.io/thingspect/atlas:9e77c656
+    image: ghcr.io/thingspect/atlas:2f9ab344
     command: atlas-alerter
     restart: on-failure
     environment:

--- a/internal/atlas-decoder/config/config.go
+++ b/internal/atlas-decoder/config/config.go
@@ -12,7 +12,8 @@ type Config struct {
 	StatsDAddr  string
 	Concurrency int
 
-	PgURI string
+	PgURI     string
+	RedisHost string
 
 	NSQPubAddr     string
 	NSQLookupAddrs []string
@@ -30,6 +31,7 @@ func New() *Config {
 
 		PgURI: config.String(pref+"PG_URI",
 			"postgres://postgres:postgres@127.0.0.1/atlas_test"),
+		RedisHost: config.String(pref+"REDIS_HOST", "127.0.0.1"),
 
 		NSQPubAddr: config.String(pref+"NSQ_PUB_ADDR", "127.0.0.1:4150"),
 		NSQLookupAddrs: config.StringSlice(pref+"NSQ_LOOKUP_ADDRS",

--- a/internal/atlas-decoder/test/main_test.go
+++ b/internal/atlas-decoder/test/main_test.go
@@ -33,6 +33,7 @@ func TestMain(m *testing.M) {
 	testConfig := testconfig.New()
 	cfg := config.New()
 	cfg.PgURI = testConfig.PgURI
+	cfg.RedisHost = testConfig.RedisHost
 
 	cfg.NSQPubAddr = testConfig.NSQPubAddr
 	cfg.NSQLookupAddrs = testConfig.NSQLookupAddrs

--- a/internal/atlas-validator/config/config.go
+++ b/internal/atlas-validator/config/config.go
@@ -12,7 +12,8 @@ type Config struct {
 	StatsDAddr  string
 	Concurrency int
 
-	PgURI string
+	PgURI     string
+	RedisHost string
 
 	NSQPubAddr     string
 	NSQLookupAddrs []string
@@ -30,6 +31,7 @@ func New() *Config {
 
 		PgURI: config.String(pref+"PG_URI",
 			"postgres://postgres:postgres@127.0.0.1/atlas_test"),
+		RedisHost: config.String(pref+"REDIS_HOST", "127.0.0.1"),
 
 		NSQPubAddr: config.String(pref+"NSQ_PUB_ADDR", "127.0.0.1:4150"),
 		NSQLookupAddrs: config.StringSlice(pref+"NSQ_LOOKUP_ADDRS",

--- a/internal/atlas-validator/test/main_test.go
+++ b/internal/atlas-validator/test/main_test.go
@@ -33,6 +33,7 @@ func TestMain(m *testing.M) {
 	testConfig := testconfig.New()
 	cfg := config.New()
 	cfg.PgURI = testConfig.PgURI
+	cfg.RedisHost = testConfig.RedisHost
 
 	cfg.NSQPubAddr = testConfig.NSQPubAddr
 	cfg.NSQLookupAddrs = testConfig.NSQLookupAddrs


### PR DESCRIPTION
- All test variations pass.