### PR TITLE
Refactor eventer service for legibility

### DIFF
--- a/build/deploy/atlas/docker-compose.yml
+++ b/build/deploy/atlas/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   atlas-api:
-    image: ghcr.io/thingspect/atlas:2a02e705
+    image: ghcr.io/thingspect/atlas:8ef215b5
     command: atlas-api
     restart: on-failure
     ports:
@@ -22,7 +22,7 @@ services:
       - API_LORA_DEV_PROF_ID=00000000-0000-0000-0000-000000000000
 
   atlas-mqtt-ingestor:
-    image: ghcr.io/thingspect/atlas:2a02e705
+    image: ghcr.io/thingspect/atlas:8ef215b5
     command: atlas-mqtt-ingestor
     restart: on-failure
     depends_on:
@@ -34,7 +34,7 @@ services:
       - MQTT_INGEST_NSQ_PUB_ADDR=nsqd:4150
 
   atlas-lora-ingestor:
-    image: ghcr.io/thingspect/atlas:2a02e705
+    image: ghcr.io/thingspect/atlas:8ef215b5
     command: atlas-lora-ingestor
     restart: on-failure
     depends_on:
@@ -47,7 +47,7 @@ services:
       - LORA_INGEST_NSQ_PUB_ADDR=nsqd:4150
 
   atlas-decoder:
-    image: ghcr.io/thingspect/atlas:2a02e705
+    image: ghcr.io/thingspect/atlas:8ef215b5
     command: atlas-decoder
     restart: on-failure
     depends_on:
@@ -60,7 +60,7 @@ services:
       - DECODER_NSQ_LOOKUP_ADDRS=nsqlookupd:4161
 
   atlas-validator:
-    image: ghcr.io/thingspect/atlas:2a02e705
+    image: ghcr.io/thingspect/atlas:8ef215b5
     command: atlas-validator
     restart: on-failure
     depends_on:
@@ -74,7 +74,7 @@ services:
       - VALIDATOR_NSQ_LOOKUP_ADDRS=nsqlookupd:4161
 
   atlas-accumulator:
-    image: ghcr.io/thingspect/atlas:2a02e705
+    image: ghcr.io/thingspect/atlas:8ef215b5
     command: atlas-accumulator
     restart: on-failure
     environment:
@@ -84,7 +84,7 @@ services:
       - ACCUMULATOR_NSQ_LOOKUP_ADDRS=nsqlookupd:4161
 
   atlas-eventer:
-    image: ghcr.io/thingspect/atlas:2a02e705
+    image: ghcr.io/thingspect/atlas:8ef215b5
     command: atlas-eventer
     restart: on-failure
     depends_on:
@@ -96,7 +96,7 @@ services:
       - EVENTER_NSQ_LOOKUP_ADDRS=nsqlookupd:4161
 
   atlas-alerter:
-    image: ghcr.io/thingspect/atlas:2a02e705
+    image: ghcr.io/thingspect/atlas:8ef215b5
     command: atlas-alerter
     restart: on-failure
     environment:

--- a/pkg/metric/default.go
+++ b/pkg/metric/default.go
@@ -7,7 +7,7 @@ import (
 
 // Since metricer is global and may be replaced, locking is required.
 var (
-	metricer   Metricer
+	metricer   Metricer = &noOpMetric{}
 	metricerMu sync.Mutex
 )
 
@@ -23,9 +23,8 @@ func getDefault() Metricer {
 // setDefault sets a new default metricer.
 func setDefault(m Metricer) {
 	metricerMu.Lock()
-	defer metricerMu.Unlock()
-
 	metricer = m
+	metricerMu.Unlock()
 }
 
 // Incr increments a statsd count metric by 1.

--- a/pkg/metric/init.go
+++ b/pkg/metric/init.go
@@ -1,5 +1,0 @@
-package metric
-
-func init() {
-	setDefault(&noOpMetric{})
-}

--- a/pkg/metric/statsd_test.go
+++ b/pkg/metric/statsd_test.go
@@ -14,12 +14,12 @@ import (
 func TestStatsD(t *testing.T) {
 	t.Parallel()
 
-	metricer := statsD{
+	metStats := statsD{
 		client: statsd.NewClient("127.0.0.1:8125",
 			statsd.TagStyle(statsd.TagFormatGraphite),
 			statsd.MetricPrefix("teststatsd.")),
 	}
-	t.Logf("metricer: %#v", metricer)
+	t.Logf("metStats: %#v", metStats)
 
 	for i := 0; i < 5; i++ {
 		lTest := i
@@ -27,12 +27,12 @@ func TestStatsD(t *testing.T) {
 		t.Run(fmt.Sprintf("Can send %v", lTest), func(t *testing.T) {
 			t.Parallel()
 
-			metricer.Incr(random.String(10), nil)
-			metricer.Count(random.String(10), random.Intn(99),
+			metStats.Incr(random.String(10), nil)
+			metStats.Count(random.String(10), random.Intn(99),
 				map[string]string{random.String(10): random.String(10)})
-			metricer.Set(random.String(10), random.Intn(99),
+			metStats.Set(random.String(10), random.Intn(99),
 				map[string]string{random.String(10): random.String(10)})
-			metricer.Timing(random.String(10),
+			metStats.Timing(random.String(10),
 				time.Duration(random.Intn(99))*time.Millisecond, nil)
 		})
 	}
@@ -47,12 +47,12 @@ func TestSetStatsD(t *testing.T) {
 		t.Run(fmt.Sprintf("Can send %v", lTest), func(t *testing.T) {
 			t.Parallel()
 
-			metricer.Incr(random.String(10), nil)
-			metricer.Count(random.String(10), random.Intn(99),
+			Incr(random.String(10), nil)
+			Count(random.String(10), random.Intn(99),
 				map[string]string{random.String(10): random.String(10)})
-			metricer.Set(random.String(10), random.Intn(99),
+			Set(random.String(10), random.Intn(99),
 				map[string]string{random.String(10): random.String(10)})
-			metricer.Timing(random.String(10),
+			Timing(random.String(10),
 				time.Duration(random.Intn(99))*time.Millisecond, nil)
 		})
 	}
@@ -69,10 +69,10 @@ func TestNewStatsDNoAddr(t *testing.T) {
 		t.Run(fmt.Sprintf("Can send %v", lTest), func(t *testing.T) {
 			t.Parallel()
 
-			metricer.Incr(random.String(10), nil)
-			metricer.Count(random.String(10), random.Intn(99),
+			Incr(random.String(10), nil)
+			Count(random.String(10), random.Intn(99),
 				map[string]string{random.String(10): random.String(10)})
-			metricer.Timing(random.String(10),
+			Timing(random.String(10),
 				time.Duration(random.Intn(99))*time.Millisecond, nil)
 		})
 	}


### PR DESCRIPTION
- Remove pkg/metric use of `init()`.
- All test variations pass.