### PR TITLE
Update datapoint and event DAO for RW and RO database connections

### DIFF
--- a/build/deploy/atlas/docker-compose.yml
+++ b/build/deploy/atlas/docker-compose.yml
@@ -80,7 +80,8 @@ services:
     restart: on-failure
     environment:
       - ACCUMULATOR_STATSD_ADDR=dogstatsd:8125
-      - ACCUMULATOR_PG_URI=postgres://postgres:notasecurepassword@postgres/atlas
+      - ACCUMULATOR_PG_RW_URI=postgres://postgres:notasecurepassword@postgres/atlas
+      - ACCUMULATOR_PG_RO_URI=postgres://postgres:notasecurepassword@postgres/atlas
       - ACCUMULATOR_NSQ_PUB_ADDR=nsqd:4150
       - ACCUMULATOR_NSQ_LOOKUP_ADDRS=nsqlookupd:4161
 
@@ -92,7 +93,8 @@ services:
       - atlas-alerter
     environment:
       - EVENTER_STATSD_ADDR=dogstatsd:8125
-      - EVENTER_PG_URI=postgres://postgres:notasecurepassword@postgres/atlas
+      - EVENTER_PG_RW_URI=postgres://postgres:notasecurepassword@postgres/atlas
+      - EVENTER_PG_RO_URI=postgres://postgres:notasecurepassword@postgres/atlas
       - EVENTER_NSQ_PUB_ADDR=nsqd:4150
       - EVENTER_NSQ_LOOKUP_ADDRS=nsqlookupd:4161
 

--- a/internal/atlas-accumulator/accumulator/accumulator.go
+++ b/internal/atlas-accumulator/accumulator/accumulator.go
@@ -37,7 +37,12 @@ type Accumulator struct {
 // value.
 func New(cfg *config.Config) (*Accumulator, error) {
 	// Set up database connection.
-	pg, err := dao.NewPgDB(cfg.PgURI)
+	pgRW, err := dao.NewPgDB(cfg.PgRwURI)
+	if err != nil {
+		return nil, err
+	}
+
+	pgRO, err := dao.NewPgDB(cfg.PgRoURI)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +66,7 @@ func New(cfg *config.Config) (*Accumulator, error) {
 	}
 
 	return &Accumulator{
-		dpDAO: datapoint.NewDAO(pg),
+		dpDAO: datapoint.NewDAO(pgRW, pgRO),
 
 		accQueue: nsq,
 		vOutSub:  vOutSub,

--- a/internal/atlas-accumulator/config/config.go
+++ b/internal/atlas-accumulator/config/config.go
@@ -12,7 +12,8 @@ type Config struct {
 	StatsDAddr  string
 	Concurrency int
 
-	PgURI string
+	PgRwURI string
+	PgRoURI string
 
 	NSQPubAddr     string
 	NSQLookupAddrs []string
@@ -27,7 +28,9 @@ func New() *Config {
 		StatsDAddr:  config.String(pref+"STATSD_ADDR", ""),
 		Concurrency: config.Int(pref+"CONCURRENCY", 5),
 
-		PgURI: config.String(pref+"PG_URI",
+		PgRwURI: config.String(pref+"PG_RW_URI",
+			"postgres://postgres:postgres@127.0.0.1/atlas_test"),
+		PgRoURI: config.String(pref+"PG_RO_URI",
 			"postgres://postgres:postgres@127.0.0.1/atlas_test"),
 
 		NSQPubAddr: config.String(pref+"NSQ_PUB_ADDR", "127.0.0.1:4150"),

--- a/internal/atlas-accumulator/test/main_test.go
+++ b/internal/atlas-accumulator/test/main_test.go
@@ -31,7 +31,8 @@ func TestMain(m *testing.M) {
 	// Set up Config.
 	testConfig := testconfig.New()
 	cfg := config.New()
-	cfg.PgURI = testConfig.PgURI
+	cfg.PgRwURI = testConfig.PgURI
+	cfg.PgRoURI = testConfig.PgURI
 
 	cfg.NSQPubAddr = testConfig.NSQPubAddr
 	cfg.NSQLookupAddrs = testConfig.NSQLookupAddrs
@@ -61,13 +62,13 @@ func TestMain(m *testing.M) {
 	}()
 
 	// Set up database connection.
-	pg, err := dao.NewPgDB(cfg.PgURI)
+	pg, err := dao.NewPgDB(cfg.PgRwURI)
 	if err != nil {
 		log.Fatalf("TestMain dao.NewPgDB: %v", err)
 	}
 	globalOrgDAO = org.NewDAO(pg)
 	globalDevDAO = device.NewDAO(pg, nil, 0)
-	globalDPDAO = datapoint.NewDAO(pg)
+	globalDPDAO = datapoint.NewDAO(pg, pg)
 
 	os.Exit(m.Run())
 }

--- a/internal/atlas-api/api/api.go
+++ b/internal/atlas-api/api/api.go
@@ -135,10 +135,11 @@ func New(cfg *config.Config) (*API, error) {
 	api.RegisterAlertServiceServer(srv, service.NewAlert(alert.NewDAO(pgRW,
 		pgRO)))
 	api.RegisterDataPointServiceServer(srv, service.NewDataPoint(nsq,
-		cfg.NSQPubTopic, datapoint.NewDAO(pgRW)))
+		cfg.NSQPubTopic, datapoint.NewDAO(pgRW, pgRO)))
 	api.RegisterDeviceServiceServer(srv, service.NewDevice(device.NewDAO(pgRW,
 		redis, deviceExp), cs))
-	api.RegisterEventServiceServer(srv, service.NewEvent(event.NewDAO(pgRW)))
+	api.RegisterEventServiceServer(srv, service.NewEvent(event.NewDAO(pgRW,
+		pgRO)))
 	api.RegisterOrgServiceServer(srv, service.NewOrg(org.NewDAO(pgRW)))
 	api.RegisterRuleAlarmServiceServer(srv,
 		service.NewRuleAlarm(rule.NewDAO(pgRW), alarm.NewDAO(pgRW)))

--- a/internal/atlas-api/test/main_test.go
+++ b/internal/atlas-api/test/main_test.go
@@ -95,8 +95,8 @@ func TestMain(m *testing.M) {
 	}
 	globalOrgDAO = org.NewDAO(pg)
 	globalUserDAO = user.NewDAO(pg)
-	globalDPDAO = datapoint.NewDAO(pg)
-	globalEvDAO = event.NewDAO(pg)
+	globalDPDAO = datapoint.NewDAO(pg, pg)
+	globalEvDAO = event.NewDAO(pg, pg)
 	globalAleDAO = alert.NewDAO(pg, pg)
 
 	globalPass = random.String(10)

--- a/internal/atlas-eventer/config/config.go
+++ b/internal/atlas-eventer/config/config.go
@@ -12,7 +12,8 @@ type Config struct {
 	StatsDAddr  string
 	Concurrency int
 
-	PgURI string
+	PgRwURI string
+	PgRoURI string
 
 	NSQPubAddr     string
 	NSQLookupAddrs []string
@@ -28,7 +29,9 @@ func New() *Config {
 		StatsDAddr:  config.String(pref+"STATSD_ADDR", ""),
 		Concurrency: config.Int(pref+"CONCURRENCY", 5),
 
-		PgURI: config.String(pref+"PG_URI",
+		PgRwURI: config.String(pref+"PG_RW_URI",
+			"postgres://postgres:postgres@127.0.0.1/atlas_test"),
+		PgRoURI: config.String(pref+"PG_RO_URI",
 			"postgres://postgres:postgres@127.0.0.1/atlas_test"),
 
 		NSQPubAddr: config.String(pref+"NSQ_PUB_ADDR", "127.0.0.1:4150"),

--- a/internal/atlas-eventer/eventer/eventer.go
+++ b/internal/atlas-eventer/eventer/eventer.go
@@ -45,7 +45,12 @@ type Eventer struct {
 // New builds a new Eventer and returns a reference to it and an error value.
 func New(cfg *config.Config) (*Eventer, error) {
 	// Set up database connection.
-	pg, err := dao.NewPgDB(cfg.PgURI)
+	pgRW, err := dao.NewPgDB(cfg.PgRwURI)
+	if err != nil {
+		return nil, err
+	}
+
+	pgRO, err := dao.NewPgDB(cfg.PgRoURI)
 	if err != nil {
 		return nil, err
 	}
@@ -69,8 +74,8 @@ func New(cfg *config.Config) (*Eventer, error) {
 	}
 
 	return &Eventer{
-		ruleDAO: rule.NewDAO(pg),
-		evDAO:   event.NewDAO(pg),
+		ruleDAO: rule.NewDAO(pgRW),
+		evDAO:   event.NewDAO(pgRW, pgRO),
 
 		evQueue:      nsq,
 		vOutSub:      vOutSub,

--- a/internal/atlas-eventer/test/main_test.go
+++ b/internal/atlas-eventer/test/main_test.go
@@ -36,7 +36,8 @@ func TestMain(m *testing.M) {
 	// Set up Config.
 	testConfig := testconfig.New()
 	cfg := config.New()
-	cfg.PgURI = testConfig.PgURI
+	cfg.PgRwURI = testConfig.PgURI
+	cfg.PgRoURI = testConfig.PgURI
 
 	cfg.NSQPubAddr = testConfig.NSQPubAddr
 	cfg.NSQLookupAddrs = testConfig.NSQLookupAddrs
@@ -70,14 +71,14 @@ func TestMain(m *testing.M) {
 	}()
 
 	// Set up database connection.
-	pg, err := dao.NewPgDB(cfg.PgURI)
+	pg, err := dao.NewPgDB(cfg.PgRwURI)
 	if err != nil {
 		log.Fatalf("TestMain dao.NewPgDB: %v", err)
 	}
 	globalOrgDAO = org.NewDAO(pg)
 	globalDevDAO = device.NewDAO(pg, nil, 0)
 	globalRuleDAO = rule.NewDAO(pg)
-	globalEvDAO = event.NewDAO(pg)
+	globalEvDAO = event.NewDAO(pg, pg)
 
 	// Set up NSQ subscription to verify published messages.
 	globalEOutSub, err = globalEvQueue.Subscribe(cfg.NSQPubTopic)

--- a/pkg/dao/datapoint/crudl.go
+++ b/pkg/dao/datapoint/crudl.go
@@ -45,9 +45,9 @@ func (d *DAO) Create(
 		bytesVal = v.BytesVal
 	}
 
-	_, err := d.pg.ExecContext(ctx, createDataPoint, orgID,
-		strings.ToLower(point.GetUniqId()), point.GetAttr(), intVal, fl64Val, strVal,
-		boolVal, bytesVal, createdAt, point.GetTraceId())
+	_, err := d.rw.ExecContext(ctx, createDataPoint, orgID,
+		strings.ToLower(point.GetUniqId()), point.GetAttr(), intVal, fl64Val,
+		strVal, boolVal, bytesVal, createdAt, point.GetTraceId())
 
 	return dao.DBToSentinel(err)
 }
@@ -105,7 +105,7 @@ func (d *DAO) List(
 	query += listDataPointsOrder
 
 	// Run list query.
-	rows, err := d.pg.QueryContext(ctx, query, args...)
+	rows, err := d.ro.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, dao.DBToSentinel(err)
 	}
@@ -249,7 +249,7 @@ func (d *DAO) Latest(
 	}
 
 	// Run latest query.
-	rows, err := d.pg.QueryContext(ctx, query, args...)
+	rows, err := d.ro.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, dao.DBToSentinel(err)
 	}

--- a/pkg/dao/datapoint/dao.go
+++ b/pkg/dao/datapoint/dao.go
@@ -8,12 +8,14 @@ import (
 
 // DAO contains functions to create and query data points in the database.
 type DAO struct {
-	pg *sql.DB
+	rw *sql.DB
+	ro *sql.DB
 }
 
 // NewDAO instantiates and returns a new DAO.
-func NewDAO(pg *sql.DB) *DAO {
+func NewDAO(rw *sql.DB, ro *sql.DB) *DAO {
 	return &DAO{
-		pg: pg,
+		rw: rw,
+		ro: ro,
 	}
 }

--- a/pkg/dao/datapoint/main_test.go
+++ b/pkg/dao/datapoint/main_test.go
@@ -30,7 +30,7 @@ func TestMain(m *testing.M) {
 	}
 	globalOrgDAO = org.NewDAO(pg)
 	globalDevDAO = device.NewDAO(pg, nil, 0)
-	globalDPDAO = NewDAO(pg)
+	globalDPDAO = NewDAO(pg, pg)
 
 	os.Exit(m.Run())
 }

--- a/pkg/dao/event/crudl.go
+++ b/pkg/dao/event/crudl.go
@@ -22,8 +22,9 @@ func (d *DAO) Create(ctx context.Context, event *api.Event) error {
 	// Truncate timestamp to milliseconds for deduplication.
 	createdAt := event.GetCreatedAt().AsTime().Truncate(time.Millisecond)
 
-	_, err := d.pg.ExecContext(ctx, createEvent, event.GetOrgId(),
-		strings.ToLower(event.GetUniqId()), event.GetRuleId(), createdAt, event.GetTraceId())
+	_, err := d.rw.ExecContext(ctx, createEvent, event.GetOrgId(),
+		strings.ToLower(event.GetUniqId()), event.GetRuleId(), createdAt,
+		event.GetTraceId())
 
 	return dao.DBToSentinel(err)
 }
@@ -79,7 +80,7 @@ func (d *DAO) List(
 	query += listEventsOrder
 
 	// Run list query.
-	rows, err := d.pg.QueryContext(ctx, query, args...)
+	rows, err := d.ro.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, dao.DBToSentinel(err)
 	}
@@ -164,7 +165,7 @@ func (d *DAO) Latest(ctx context.Context, orgID, ruleID string) (
 	query += latestEventsOrder
 
 	// Run latest query.
-	rows, err := d.pg.QueryContext(ctx, query, args...)
+	rows, err := d.ro.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, dao.DBToSentinel(err)
 	}

--- a/pkg/dao/event/dao.go
+++ b/pkg/dao/event/dao.go
@@ -7,12 +7,14 @@ import (
 
 // DAO contains functions to create and query events in the database.
 type DAO struct {
-	pg *sql.DB
+	rw *sql.DB
+	ro *sql.DB
 }
 
 // NewDAO instantiates and returns a new DAO.
-func NewDAO(pg *sql.DB) *DAO {
+func NewDAO(rw *sql.DB, ro *sql.DB) *DAO {
 	return &DAO{
-		pg: pg,
+		rw: rw,
+		ro: ro,
 	}
 }

--- a/pkg/dao/event/main_test.go
+++ b/pkg/dao/event/main_test.go
@@ -30,7 +30,7 @@ func TestMain(m *testing.M) {
 	}
 	globalOrgDAO = org.NewDAO(pg)
 	globalDevDAO = device.NewDAO(pg, nil, 0)
-	globalEvDAO = NewDAO(pg)
+	globalEvDAO = NewDAO(pg, pg)
 
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
- Update DAO, integration tests, and atlas-accumulator, atlas-api, and atlas-eventer services.
- All test variations pass.