### PR TITLE
Remove GitHub CI cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,10 @@ jobs:
         image: redis:7-alpine
     steps:
       - name: Deps
-        # Add packages needed to support checkout, cache, builds, and tests
+        # Add packages needed to support checkout, builds, and tests
         run: |
           apk update && apk upgrade
-          apk add --no-cache git tar make
+          apk add --no-cache git make
           go env
       - name: Clone
         uses: actions/checkout@v4
@@ -54,13 +54,6 @@ jobs:
         uses: docker://docker
         with:
           args: docker restart mqtt
-      - name: Cache
-        uses: actions/cache@v4
-        with:
-          # Cache modules only, not build
-          path: /go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('Makefile') }}
-          restore-keys: ${{ runner.os }}-go-
       - name: Build_and_Test
         run: make test
       - name: Push

--- a/build/deploy/atlas/docker-compose.yml
+++ b/build/deploy/atlas/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   atlas-api:
-    image: ghcr.io/thingspect/atlas:7a626795
+    image: ghcr.io/thingspect/atlas:981a73e4
     command: atlas-api
     restart: on-failure
     ports:
@@ -22,7 +22,7 @@ services:
       - API_LORA_DEV_PROF_ID=00000000-0000-0000-0000-000000000000
 
   atlas-mqtt-ingestor:
-    image: ghcr.io/thingspect/atlas:7a626795
+    image: ghcr.io/thingspect/atlas:981a73e4
     command: atlas-mqtt-ingestor
     restart: on-failure
     depends_on:
@@ -34,7 +34,7 @@ services:
       - MQTT_INGEST_NSQ_PUB_ADDR=nsqd:4150
 
   atlas-lora-ingestor:
-    image: ghcr.io/thingspect/atlas:7a626795
+    image: ghcr.io/thingspect/atlas:981a73e4
     command: atlas-lora-ingestor
     restart: on-failure
     depends_on:
@@ -47,7 +47,7 @@ services:
       - LORA_INGEST_NSQ_PUB_ADDR=nsqd:4150
 
   atlas-decoder:
-    image: ghcr.io/thingspect/atlas:7a626795
+    image: ghcr.io/thingspect/atlas:981a73e4
     command: atlas-decoder
     restart: on-failure
     depends_on:
@@ -61,7 +61,7 @@ services:
       - DECODER_NSQ_LOOKUP_ADDRS=nsqlookupd:4161
 
   atlas-validator:
-    image: ghcr.io/thingspect/atlas:7a626795
+    image: ghcr.io/thingspect/atlas:981a73e4
     command: atlas-validator
     restart: on-failure
     depends_on:
@@ -76,7 +76,7 @@ services:
       - VALIDATOR_NSQ_LOOKUP_ADDRS=nsqlookupd:4161
 
   atlas-accumulator:
-    image: ghcr.io/thingspect/atlas:7a626795
+    image: ghcr.io/thingspect/atlas:981a73e4
     command: atlas-accumulator
     restart: on-failure
     environment:
@@ -87,7 +87,7 @@ services:
       - ACCUMULATOR_NSQ_LOOKUP_ADDRS=nsqlookupd:4161
 
   atlas-eventer:
-    image: ghcr.io/thingspect/atlas:7a626795
+    image: ghcr.io/thingspect/atlas:981a73e4
     command: atlas-eventer
     restart: on-failure
     depends_on:
@@ -100,7 +100,7 @@ services:
       - EVENTER_NSQ_LOOKUP_ADDRS=nsqlookupd:4161
 
   atlas-alerter:
-    image: ghcr.io/thingspect/atlas:7a626795
+    image: ghcr.io/thingspect/atlas:981a73e4
     command: atlas-alerter
     restart: on-failure
     environment:


### PR DESCRIPTION
- It is no faster than the Go package proxy and adds complexity.
- All test variations pass.